### PR TITLE
Small patch to fix the RPM build on CentOS 5.5

### DIFF
--- a/packaging/RPM/libiscsi.spec.in
+++ b/packaging/RPM/libiscsi.spec.in
@@ -58,7 +58,7 @@ mkdir -p $RPM_BUILD_ROOT%{_includedir}
 mkdir -p $RPM_BUILD_ROOT%{_includedir}/iscsi
 
 #
-make DESTDIR=$RPM_BUILD_ROOT LIBDIR=$RPM_BUILD_ROOT%{_libdir} install
+make DESTDIR=$RPM_BUILD_ROOT%{_prefix} LIBDIR=$RPM_BUILD_ROOT%{_libdir} install
 
 # Remove "*.old" files
 find $RPM_BUILD_ROOT -name "*.old" -exec rm -f {} \;


### PR DESCRIPTION
This is needed because prefix is being set directly to $(DESTDIR) in Makefile.in, overriding the --prefix argument to configure.

With this change makerpms.sh is working nicely.

Cheers,
Dave
