### PR TITLE
SCSI add support for iovectors

### DIFF
--- a/include/iscsi.h
+++ b/include/iscsi.h
@@ -950,6 +950,11 @@ iscsi_report_supported_opcodes_sync(struct iscsi_context *iscsi, int lun,
  * task->datain.data will be NULL
  */
 EXTERN int scsi_task_add_data_in_buffer(struct scsi_task *task, int len, unsigned char *buf);
+EXTERN int scsi_task_add_data_out_buffer(struct scsi_task *task, int len, unsigned char *buf);
+
+struct scsi_iovec;
+EXTERN void scsi_task_set_iov_out(struct scsi_task *task, struct scsi_iovec *iov, int niov);
+EXTERN void scsi_task_set_iov_in(struct scsi_task *task, struct scsi_iovec *iov, int niov);
 
 /*
  * This function is used when you want to cancel a scsi task.

--- a/include/scsi-lowlevel.h
+++ b/include/scsi-lowlevel.h
@@ -197,18 +197,20 @@ enum scsi_residual {
 	SCSI_RESIDUAL_OVERFLOW
 };
 
-#if !defined(_SYS_UIO_H) && !defined(CONFIG_IOVEC)
-struct iovec {
+/* struct scsi_iovec follows the POSIX struct iovec
+   definition and *MUST* never change. */
+struct scsi_iovec {
     void *iov_base;
     size_t iov_len;
 };
-#endif
 
 struct scsi_iovector {
-    struct iovec *iov;
+    struct scsi_iovec *iov;
     int niov;
     int nalloc;
     size_t size;
+	size_t offset;
+	int consumed;
 };
 
 struct scsi_task {
@@ -231,9 +233,8 @@ struct scsi_task {
 	uint32_t cmdsn;
 	uint32_t lun;
 
-	size_t buffers_offset;
-	int buffers_consumed;
-	struct scsi_iovector *buffers;
+	struct scsi_iovector iovector_in;
+	struct scsi_iovector iovector_out;
 };
 
 /* This function will free a scsi task structure.
@@ -722,8 +723,6 @@ EXTERN struct scsi_task *scsi_cdb_prefetch16(uint64_t lba, int num_blocks, int i
 EXTERN struct scsi_task *scsi_cdb_report_supported_opcodes(int report_timeouts, uint32_t alloc_len);
 
 void *scsi_malloc(struct scsi_task *task, size_t size);
-
-EXTERN void scsi_iovector_assign(struct scsi_task *task, struct scsi_iovector *iov);
 
 #ifdef __cplusplus
 }

--- a/lib/init.c
+++ b/lib/init.c
@@ -32,7 +32,6 @@
 #include "iscsi.h"
 #include "iscsi-private.h"
 #include "slist.h"
-#include "scsi-lowlevel.h"
 
 
 inline void* iscsi_malloc(struct iscsi_context *iscsi, size_t size) {

--- a/lib/libiscsi.def
+++ b/lib/libiscsi.def
@@ -176,5 +176,7 @@ scsi_sense_ascq_str
 scsi_sense_key_str
 scsi_set_task_private_ptr
 scsi_task_add_data_in_buffer
-scsi_iovector_assign
+scsi_task_add_data_out_buffer
+scsi_task_set_iov_in
+scsi_task_set_iov_out
 scsi_version_to_str

--- a/lib/libiscsi.syms
+++ b/lib/libiscsi.syms
@@ -174,5 +174,7 @@ scsi_sense_ascq_str
 scsi_sense_key_str
 scsi_set_task_private_ptr
 scsi_task_add_data_in_buffer
-scsi_iovector_assign
+scsi_task_add_data_out_buffer
+scsi_task_set_iov_in
+scsi_task_set_iov_out
 scsi_version_to_str


### PR DESCRIPTION
If an application passes buffers to libiscsi for reading they are
currently added to a linked list one by one. This leads to a malloc
for each buffer object plus O(n) walks trough the list to add
the buffer to then end of the list. Additionally the buffer read
routine takes up to O(n) iterations to find the right buffer
for a request.

This patch introduces an scsi_iovector struct to pass buffers to
an scsi task. Adding a new buffer is in O(1) and finding the
right buffer to also. Malloc requirements are in O(log(n)).

Additionally the scsi_iovector struct is itended to be binary
compatible to an QEMUIOVector allowing to pass this structure
directly to the library.

Initial tests have been made booting an Ubuntu LTS 12.04.1
Desktop server up to the login prompt. The following observations
have been made with regards to scsi_malloc calls:

original implementation:    ~11.500 mallocs
using iovector instead of list: ~ 7.500 mallocs
passing the iovector directly:        0 mallocs

To enable this feature in qemu for testing the following patch might
be used:

diff --git a/block/iscsi.c b/block/iscsi.c
index a6a819d..2809c15 100644
--- a/block/iscsi.c
+++ b/block/iscsi.c
@@ -390,11 +390,16 @@ iscsi_aio_readv(BlockDriverState *bs, int64_t sector_num,
         return NULL;
     }

+#if defined(LIBISCSI_FEATURE_IOVECTOR)
-    assert(sizeof(struct QEMUIOVector) == sizeof(struct scsi_iovector));
-    scsi_iovector_assign(acb->task, (struct scsi_iovector*) acb->qiov);
  +#else
   for (i = 0; i < acb->qiov->niov; i++) {
       scsi_task_add_data_in_buffer(acb->task,
               acb->qiov->iov[i].iov_len,
               acb->qiov->iov[i].iov_base);
   }
  +#endif
  
   iscsi_set_events(iscsilun);

---

Signed-off-by: Peter Lieven pl@kamp.de
