### PR TITLE
ISCSI fix leaked memory report

### DIFF
--- a/lib/iscsi-command.c
+++ b/lib/iscsi-command.c
@@ -377,6 +377,12 @@ iscsi_process_scsi_reply(struct iscsi_context *iscsi, struct iscsi_pdu *pdu,
 			}
 		}
 
+		/* the pdu->datain.data was malloc'ed by iscsi_malloc,
+		   as long as we have no struct iscsi_task we cannot track
+		   the free'ing of this buffer which is currently
+		   done in scsi_free_scsi_task() */
+		if (pdu->indata.data != NULL) iscsi->frees++;
+
 		pdu->indata.data = NULL;
 		pdu->indata.size = 0;
 
@@ -511,6 +517,12 @@ iscsi_process_scsi_data_in(struct iscsi_context *iscsi, struct iscsi_pdu *pdu,
 	task->datain.data = pdu->indata.data;
 	task->datain.size = pdu->indata.size;
 
+	/* the pdu->indata.data was malloc'ed by iscsi_malloc,
+	   as long as we have no struct iscsi_task we cannot track
+	   the free'ing of this buffer which is currently
+	   done in scsi_free_scsi_task() */
+	if (pdu->indata.data != NULL) iscsi->frees++;
+	
 	pdu->indata.data = NULL;
 	pdu->indata.size = 0;
 


### PR DESCRIPTION
As long as we have no struct iscsi_task we cannot track the
free() of data.indata buffer. This leads to a leaked memory
report in iscsi_context_destroy().

We fix this by assuming it has been freed when we pass it
it to scsi_task.

Signed-off-by: Peter Lieven pl@kamp.de
