### PR TITLE
ISCSI_PDU nest iscsi_scsi_cbdata

### DIFF
--- a/include/iscsi-private.h
+++ b/include/iscsi-private.h
@@ -192,6 +192,13 @@ enum iscsi_opcode {
 	ISCSI_PDU_NO_PDU	                 = 0xff
 };
 
+struct iscsi_scsi_cbdata {
+	struct iscsi_scsi_cbdata *prev, *next;
+	iscsi_command_cb          callback;
+	void                     *private_data;
+	struct scsi_task         *task;
+};
+
 struct iscsi_pdu {
 	struct iscsi_pdu *next;
 
@@ -216,7 +223,7 @@ struct iscsi_pdu {
 
 	struct iscsi_data nidata; /* Non-Immediate Data */
 
-	struct iscsi_scsi_cbdata *scsi_cbdata;
+	struct iscsi_scsi_cbdata scsi_cbdata;
 };
 
 void iscsi_free_scsi_cbdata(struct iscsi_context *iscsi, struct iscsi_scsi_cbdata *scsi_cbdata);

--- a/lib/pdu.c
+++ b/lib/pdu.c
@@ -115,11 +115,6 @@ iscsi_free_pdu(struct iscsi_context *iscsi, struct iscsi_pdu *pdu)
 	iscsi_free(iscsi, pdu->indata.data);
 	pdu->indata.data = NULL;
 
-	if (pdu->scsi_cbdata) {
-		iscsi_free_scsi_cbdata(iscsi, pdu->scsi_cbdata);
-		pdu->scsi_cbdata = NULL;
-	}
-
 	iscsi_free(iscsi, pdu);
 }
 


### PR DESCRIPTION
We can simply nest the iscsi_scsi_cbdata in the iscsi_pdu struct
since it is only used inside the iscsi_pdu.

This saves one malloc for each pdu.

Signed-off-by: Peter Lieven pl@kamp.de
