### PR TITLE
SOCKET queue cmd PDUs directly in waitpdu queue

### DIFF
--- a/include/iscsi-private.h
+++ b/include/iscsi-private.h
@@ -103,6 +103,7 @@ struct iscsi_context {
 	void *connect_data;
 
 	struct iscsi_pdu *outqueue;
+	struct iscsi_pdu *outqueue_current;
 	struct iscsi_pdu *waitpdu;
 
 	struct iscsi_in_pdu *incoming;

--- a/lib/init.c
+++ b/lib/init.c
@@ -268,6 +268,10 @@ iscsi_destroy_context(struct iscsi_context *iscsi)
 		iscsi_free_pdu(iscsi, pdu);
 	}
 
+	if (iscsi->outqueue_current != NULL && iscsi->outqueue_current->flags & ISCSI_PDU_DELETE_WHEN_SENT) {
+		iscsi_free_pdu(iscsi, iscsi->outqueue_current);
+	}
+
 	if (iscsi->incoming != NULL) {
 		iscsi_free_iscsi_in_pdu(iscsi, iscsi->incoming);
 	}

--- a/lib/pdu.c
+++ b/lib/pdu.c
@@ -369,7 +369,7 @@ iscsi_process_pdu(struct iscsi_context *iscsi, struct iscsi_in_pdu *in)
 		 */
 		if (opcode == ISCSI_PDU_R2T) {
 			expected_response = ISCSI_PDU_R2T;
-	        }
+		}
 
 		if (opcode != expected_response) {
 			iscsi_set_error(iscsi, "Got wrong opcode back for "


### PR DESCRIPTION
A storage might sent an R2T response for a WRITE command while
we still sending out the WRITE command PDU. This is especially
the case when the command PDU carries immediata data.

Without this patch the R2T response will get lost as
the cmdpdu for the R2T cannot be found in iscsi_process_pdu()
leading to a deadlock.

Signed-off-by: Peter Lieven pl@kamp.de
