### PR TITLE
RECONNECT add option to limit the number of reconnect retries

### DIFF
--- a/include/iscsi-private.h
+++ b/include/iscsi-private.h
@@ -121,6 +121,7 @@ struct iscsi_context {
 	int lun;
 	int no_auto_reconnect;
 	int reconnect_deferred;
+	int reconnect_max_retries;
 	
 	int log_level;
 	iscsi_log_fn log_fn;

--- a/include/iscsi.h
+++ b/include/iscsi.h
@@ -1076,6 +1076,16 @@ iscsi_set_tcp_syncnt(struct iscsi_context *iscsi, int value);
 EXTERN void
 iscsi_set_bind_interfaces(struct iscsi_context *iscsi, char * interfaces);
 
+/* This function is to set if we should retry a failed reconnect
+   
+   count is defined as follows:
+    -1 -> retry forever (default)
+    0  -> never retry
+    n  -> retry n times
+*/
+EXTERN void
+iscsi_set_reconnect_max_retries(struct iscsi_context *iscsi, int count);
+
 #ifdef __cplusplus
 }
 #endif

--- a/lib/init.c
+++ b/lib/init.c
@@ -112,6 +112,8 @@ iscsi_create_context(const char *initiator_name)
 	iscsi->tcp_keepcnt=3;
 	iscsi->tcp_keepintvl=30;
 	iscsi->tcp_keepidle=30;
+	
+	iscsi->reconnect_max_retries = -1;
 
 	if (getenv("LIBISCSI_DEBUG") != NULL) {
 		iscsi_set_log_level(iscsi, atoi(getenv("LIBISCSI_DEBUG")));

--- a/lib/libiscsi.def
+++ b/lib/libiscsi.def
@@ -57,6 +57,7 @@ iscsi_report_supported_opcodes_sync
 iscsi_report_supported_opcodes_task
 iscsi_reconnect
 iscsi_set_noautoreconnect
+iscsi_set_reconnect_max_retries
 iscsi_reportluns_sync
 iscsi_reportluns_task
 iscsi_scsi_cancel_all_tasks

--- a/lib/libiscsi.syms
+++ b/lib/libiscsi.syms
@@ -55,6 +55,7 @@ iscsi_report_supported_opcodes_sync
 iscsi_report_supported_opcodes_task
 iscsi_reconnect
 iscsi_set_noautoreconnect
+iscsi_set_reconnect_max_retries
 iscsi_reportluns_sync
 iscsi_reportluns_task
 iscsi_scsi_cancel_all_tasks


### PR DESCRIPTION
In specific situation it might be useful to give up if a reconnect
is not successful or after a given number reconnect retries.
This patch adds the ability to change that. The default remains
the same: retry forever.

Signed-off-by: Peter Lieven pl@kamp.de
