### PR TITLE
Allow users to disable -Werror at configure time

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -11,8 +11,14 @@ AC_CANONICAL_HOST
 AM_CONDITIONAL(LD_ISCSI,
                [expr "$host_os" : linux > /dev/null 2>&1])
 
+AC_ARG_ENABLE([werror], [AS_HELP_STRING([--disable-werror],
+              [Disables building with -Werror by default])])
+
 if test "$ac_cv_prog_gcc" = yes; then
-   WARN_CFLAGS="-Wall -W -Wshadow -Wstrict-prototypes -Wpointer-arith -Wcast-align -Wwrite-strings -Werror -Wno-strict-aliasing"
+   WARN_CFLAGS="-Wall -W -Wshadow -Wstrict-prototypes -Wpointer-arith -Wcast-align -Wwrite-strings -Wno-strict-aliasing"
+   if test "x$enable_werror" != "xno"; then
+       WARN_CFLAGS="$WARN_CFLAGS -Werror"
+   fi
 fi
 AC_SUBST(WARN_CFLAGS)
 


### PR DESCRIPTION
Some users and distro packagers might not want to build with -Werror,
this allows them to disable using -Werror but enables it in the default
case so as to maintain the current behavior.

Currently this patch is carried by Gentoo to support our policy of not building packages with -Werror by default.
