### PR TITLE
MEMORY introduce a small allocation pool

### DIFF
--- a/include/iscsi-private.h
+++ b/include/iscsi-private.h
@@ -39,6 +39,7 @@ extern "C" {
 #define ISCSI_HEADER_SIZE (ISCSI_RAW_HEADER_SIZE	\
   + (iscsi->header_digest == ISCSI_HEADER_DIGEST_NONE?0:ISCSI_DIGEST_SIZE))
 
+#define SMALL_ALLOC_MAX_FREE (128) /* must be power of 2 */
 
 struct iscsi_in_pdu {
 	struct iscsi_in_pdu *next;
@@ -131,6 +132,10 @@ struct iscsi_context {
 	int mallocs;
 	int reallocs;
 	int frees;
+	int smallocs;
+	void* smalloc_ptrs[SMALL_ALLOC_MAX_FREE];
+	int smalloc_free;
+	size_t smalloc_size;
 
 	time_t last_reconnect;
 	int scsi_timeout;
@@ -301,6 +306,8 @@ inline void* iscsi_zmalloc(struct iscsi_context *iscsi, size_t size);
 inline void* iscsi_realloc(struct iscsi_context *iscsi, void* ptr, size_t size);
 inline void iscsi_free(struct iscsi_context *iscsi, void* ptr);
 inline char* iscsi_strdup(struct iscsi_context *iscsi, const char* str);
+inline void* iscsi_szmalloc(struct iscsi_context *iscsi, size_t size);
+inline void iscsi_sfree(struct iscsi_context *iscsi, void* ptr);
 
 unsigned long crc32c(char *buf, int len);
 

--- a/lib/pdu.c
+++ b/lib/pdu.c
@@ -84,15 +84,14 @@ iscsi_allocate_pdu_with_itt_flags(struct iscsi_context *iscsi, enum iscsi_opcode
 {
 	struct iscsi_pdu *pdu;
 
-	pdu = iscsi_zmalloc(iscsi, sizeof(struct iscsi_pdu));
+	pdu = iscsi_szmalloc(iscsi, sizeof(struct iscsi_pdu));
 	if (pdu == NULL) {
 		iscsi_set_error(iscsi, "failed to allocate pdu");
 		return NULL;
 	}
 
 	pdu->outdata.size = ISCSI_HEADER_SIZE;
-       	pdu->outdata.data = iscsi_malloc(iscsi, pdu->outdata.size);
-	memset(pdu->outdata.data, 0, ISCSI_HEADER_SIZE);
+	pdu->outdata.data = iscsi_szmalloc(iscsi, pdu->outdata.size);
 
 	if (pdu->outdata.data == NULL) {
 		iscsi_set_error(iscsi, "failed to allocate pdu header");
@@ -134,13 +133,21 @@ iscsi_free_pdu(struct iscsi_context *iscsi, struct iscsi_pdu *pdu)
 		return;
 	}
 
-	iscsi_free(iscsi, pdu->outdata.data);
+	if (pdu->outdata.size <= iscsi->smalloc_size) {
+		iscsi_sfree(iscsi, pdu->outdata.data);
+	} else {
+		iscsi_free(iscsi, pdu->outdata.data);
+	}
 	pdu->outdata.data = NULL;
 
-	iscsi_free(iscsi, pdu->indata.data);
+	if (pdu->indata.size <= iscsi->smalloc_size) {
+		iscsi_sfree(iscsi, pdu->indata.data);
+	} else {
+		iscsi_free(iscsi, pdu->indata.data);
+	}
 	pdu->indata.data = NULL;
 
-	iscsi_free(iscsi, pdu);
+	iscsi_sfree(iscsi, pdu);
 }
 
 
@@ -164,9 +171,15 @@ iscsi_add_data(struct iscsi_context *iscsi, struct iscsi_data *data,
 	}
 
 	if (data->size == 0) {
-		data->data = iscsi_malloc(iscsi, aligned);
+		if (aligned <= iscsi->smalloc_size) {
+			data->data = iscsi_szmalloc(iscsi, aligned);
+		} else {
+			data->data = iscsi_malloc(iscsi, aligned);
+		}
 	} else {
-		data->data = iscsi_realloc(iscsi, data->data, aligned);
+		if (aligned > iscsi->smalloc_size) {
+			data->data = iscsi_realloc(iscsi, data->data, aligned);
+		}
 	}
 	if (data->data == NULL) {
 		iscsi_set_error(iscsi, "failed to allocate buffer for %d "

--- a/lib/socket.c
+++ b/lib/socket.c
@@ -482,7 +482,7 @@ iscsi_read_from_socket(struct iscsi_context *iscsi)
 	ssize_t data_size, count;
 
 	if (iscsi->incoming == NULL) {
-		iscsi->incoming = iscsi_zmalloc(iscsi, sizeof(struct iscsi_in_pdu));
+		iscsi->incoming = iscsi_szmalloc(iscsi, sizeof(struct iscsi_in_pdu));
 		if (iscsi->incoming == NULL) {
 			iscsi_set_error(iscsi, "Out-of-memory: failed to malloc iscsi_in_pdu");
 			return -1;
@@ -810,7 +810,7 @@ iscsi_free_iscsi_in_pdu(struct iscsi_context *iscsi, struct iscsi_in_pdu *in)
 {
 	iscsi_free(iscsi, in->data);
 	in->data=NULL;
-	iscsi_free(iscsi, in);
+	iscsi_sfree(iscsi, in);
 	in=NULL;
 }
 


### PR DESCRIPTION
This patch finally introduces a small allocation pool
which recycles all the small portions of memory that
are used for headers and pdu structures. This was
the initial idea behind wrapping all memory functions
in libiscsi.

The results of booting are test system up to the login
prompt are quite impressive:

BEFORE:
libiscsi:5 memory is clean at iscsi_destroy_context() after 10712 mallocs, 18 realloc(s) and 10712 free(s)

AFTER:
libiscsi:5 memory is clean at iscsi_destroy_context() after 41 mallocs, 18 realloc(s), 41 free(s) and 10584 reused small allocations

Signed-off-by: Peter Lieven pl@kamp.de
