### PR TITLE
bump ABI version

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -42,7 +42,7 @@ if !HAVE_LIBGCRYPT
 lib_libiscsi_la_SOURCES += lib/md5.c
 endif
 
-SONAME=$(firstword $(subst ., ,$(VERSION)))
+SONAME=3
 SOREL=$(shell printf "%d%02d%02d" $(subst ., ,$(VERSION)))
 lib_libiscsi_la_LDFLAGS = \
 	-version-info $(SONAME):$(SOREL):0 -bindir $(bindir) -no-undefined \


### PR DESCRIPTION
The ABI version was changed many times since the first release, but no
one noticed.  Now that I am packaging a newer version of libiscsi
I need to bump the soname from 1 to 2, which will be (posthumously)
the ABI for 1.9.0.  Declare the next version to have ABI version 3.

Please do not hesitate to ask for review of header-file patches to
catch ABI changes (which should be avoided!).
