### PR TITLE
use scsi_get/set_uint16/32/64 in tests

### DIFF
--- a/lib/libiscsi.def
+++ b/lib/libiscsi.def
@@ -204,6 +204,9 @@ scsi_devqualifier_to_str
 scsi_devtype_to_str
 scsi_free_scsi_task
 scsi_get_task_private_ptr
+scsi_get_uint16
+scsi_get_uint32
+scsi_get_uint64
 scsi_inquiry_pagecode_to_str
 scsi_modesense_dataout_marshall
 scsi_modesense_get_page
@@ -212,6 +215,9 @@ scsi_reportluns_cdb
 scsi_sense_ascq_str
 scsi_sense_key_str
 scsi_set_task_private_ptr
+scsi_set_uint16
+scsi_set_uint32
+scsi_set_uint64
 scsi_task_add_data_in_buffer
 scsi_task_add_data_out_buffer
 scsi_task_set_iov_in

--- a/lib/libiscsi.syms
+++ b/lib/libiscsi.syms
@@ -202,6 +202,9 @@ scsi_devqualifier_to_str
 scsi_devtype_to_str
 scsi_free_scsi_task
 scsi_get_task_private_ptr
+scsi_get_uint16
+scsi_get_uint32
+scsi_get_uint64
 scsi_inquiry_pagecode_to_str
 scsi_modesense_dataout_marshall
 scsi_modesense_get_page
@@ -211,6 +214,9 @@ scsi_sense_ascq_str
 scsi_pr_type_str
 scsi_sense_key_str
 scsi_set_task_private_ptr
+scsi_set_uint16
+scsi_set_uint32
+scsi_set_uint64
 scsi_task_add_data_in_buffer
 scsi_task_add_data_out_buffer
 scsi_task_set_iov_in

--- a/test-tool/1000_cmdsn_invalid.c
+++ b/test-tool/1000_cmdsn_invalid.c
@@ -29,11 +29,11 @@ static int my_iscsi_queue_pdu(struct iscsi_context *iscsi, struct iscsi_pdu *pdu
 	switch (change_cmdsn) {
 	case 1:
 		/* change the cmdsn so it becomes too big */
-		*(uint32_t *)&pdu->outdata.data[24] = htonl(iscsi->maxcmdsn + 1);
+		scsi_set_uint32(&pdu->outdata.data[24], iscsi->maxcmdsn + 1);
 		break;
 	case 2:
 		/* change the cmdsn so it becomes too small */
-		*(uint32_t *)&pdu->outdata.data[24] = 0;
+		scsi_set_uint32(&pdu->outdata.data[24], 0);
 		break;
 	}
 

--- a/test-tool/1010_datasn_invalid.c
+++ b/test-tool/1010_datasn_invalid.c
@@ -34,20 +34,20 @@ static int my_iscsi_queue_pdu(struct iscsi_context *iscsi _U_, struct iscsi_pdu 
 	switch (clamp_datasn) {
 	case 1:
 		/* change datasn to 0 */
-		*(uint32_t *)&pdu->outdata.data[36] = 0;
+		scsi_set_uint32(&pdu->outdata.data[36], 0);
 		break;
 	case 2:
 		/* change datasn to 27 */
-		*(uint32_t *)&pdu->outdata.data[36] = htonl(27);
+		scsi_set_uint32(&pdu->outdata.data[36], 27);
 		break;
 	case 3:
 		/* change datasn to -1 */
-		*(uint32_t *)&pdu->outdata.data[36] = htonl(-1);
+		scsi_set_uint32(&pdu->outdata.data[36], -1);
 		break;
 	case 4:
 		/* change datasn from (0,1) to (1,0) */
-		datasn = ntohl(*(uint32_t *)&pdu->outdata.data[36]);
-		*(uint32_t *)&pdu->outdata.data[36] = htonl(1 - datasn);
+		datasn = scsi_get_uint32(&pdu->outdata.data[36]);
+		scsi_set_uint32(&pdu->outdata.data[36], 1 - datasn);
 		break;
 	}
 	return 0;

--- a/test-tool/1020_bufferoffset_invalid.c
+++ b/test-tool/1020_bufferoffset_invalid.c
@@ -31,15 +31,15 @@ static int my_iscsi_queue_pdu(struct iscsi_context *iscsi _U_, struct iscsi_pdu 
 	if (pdu->outdata.data[0] != ISCSI_PDU_DATA_OUT) {
 		return 0;
 	}
-	buffer_offset = ntohl(*(uint32_t *)&pdu->outdata.data[40]);
+	buffer_offset = scsi_get_uint32(&pdu->outdata.data[40]);
 	switch (change_bufferoffset) {
 	case 1:
 		/* Add 1M to the buffer offset */
-		*(uint32_t *)&pdu->outdata.data[40] = htonl(buffer_offset + 1024*1024);
+		scsi_set_uint32(&pdu->outdata.data[40], buffer_offset + 1024*1024);
 		break;
 	case 2:
 		/* Add -'block_size' to the buffer offset */
-		*(uint32_t *)&pdu->outdata.data[40] = htonl(buffer_offset - block_size);
+		scsi_set_uint32(&pdu->outdata.data[40], buffer_offset - block_size);
 		break;
 	}
 	return 0;

--- a/test-tool/1031_unsolicited_data_out.c
+++ b/test-tool/1031_unsolicited_data_out.c
@@ -74,8 +74,7 @@ my_iscsi_pdu_add_data(struct iscsi_context *iscsi, struct iscsi_pdu *pdu,
 	}
 
 	/* update data segment length */
-	*(uint32_t *)&pdu->outdata.data[4] = htonl(pdu->outdata.size
-						   - ISCSI_HEADER_SIZE);
+	scsi_set_uint32(&pdu->outdata.data[4], pdu->outdata.size - ISCSI_HEADER_SIZE);
 
 	return 0;
 }
@@ -83,13 +82,13 @@ my_iscsi_pdu_add_data(struct iscsi_context *iscsi, struct iscsi_pdu *pdu,
 static void
 my_iscsi_pdu_set_itt(struct iscsi_pdu *pdu, uint32_t itt)
 {
-	*(uint32_t *)&pdu->outdata.data[16] = htonl(itt);
+	scsi_set_uint32(&pdu->outdata.data[16], itt);
 }
 
 static void
 my_iscsi_pdu_set_expstatsn(struct iscsi_pdu *pdu, uint32_t expstatsnsn)
 {
-	*(uint32_t *)&pdu->outdata.data[28] = htonl(expstatsnsn);
+	scsi_set_uint32(&pdu->outdata.data[28], expstatsnsn);
 }
 
 static void

--- a/test-tool/1041_unsolicited_immediate_data.c
+++ b/test-tool/1041_unsolicited_immediate_data.c
@@ -37,7 +37,7 @@ static int my_queue_immediate_data(struct iscsi_context *iscsi _U_, struct iscsi
 		pdu_was_valid = 0;
 		return 0;
 	}
-	if ( (*(uint32_t *)&pdu->outdata.data[4] & 0x00ffffff) != htonl(block_size)) {
+	if ( (scsi_get_uint32(&pdu->outdata.data[4]) & 0x00ffffff) != block_size) {
 		printf("SCSI-Command PDU did not have one block of immediate data.\n");
 		pdu_was_valid = 0;
 		return 0;

--- a/test-tool/1042_unsolicited_nonimmediate_data.c
+++ b/test-tool/1042_unsolicited_nonimmediate_data.c
@@ -37,7 +37,7 @@ static int my_queue_immediate_data(struct iscsi_context *iscsi _U_, struct iscsi
 			pdu_was_valid = 0;
 			return 0;
 		}
-		if ( *(uint32_t *)&pdu->outdata.data[4] & 0x00ffffff ) {
+		if ( scsi_get_uint32(&pdu->outdata.data[4]) & 0x00ffffff ) {
 			printf("SCSI-Command PDU had non-zero datasegmentsize.\n");
 			pdu_was_valid = 0;
 			return 0;
@@ -50,7 +50,7 @@ static int my_queue_immediate_data(struct iscsi_context *iscsi _U_, struct iscsi
 			pdu_was_valid = 0;
 			return 0;
 		}
-		if ( (*(uint32_t *)&pdu->outdata.data[4] & 0x00ffffff) != htonl(block_size)) {
+		if ( (scsi_get_uint32(&pdu->outdata.data[4]) & 0x00ffffff) != block_size) {
 			printf("The DATA-OUT PDU did not carry a full block.\n");
 			pdu_was_valid = 0;
 			return 0;

--- a/test-tool/1100_persistent_reserve_in_read_keys_simple.c
+++ b/test-tool/1100_persistent_reserve_in_read_keys_simple.c
@@ -90,7 +90,7 @@ int T1100_persistent_reserve_in_read_keys_simple(const char *initiator, const ch
 
 	/* Verify that ADDITIONAL_LENGTH matches DATA-IN size */
 	printf("Verify that ADDITIONAL_LENGTH matches DATA-IN size ... ");
-	al = ntohl(*(uint32_t *)&task->datain.data[4]);
+	al = scsi_get_uint32(&task->datain.data[4]);
 	if (al != task->datain.size - 8) {
 	        printf("[FAILED]\n");
 		printf("ADDITIONAL_LENGTH was %d bytes but %d was expected.\n",

--- a/test-tool/test_iscsi_cmdsn_toohigh.c
+++ b/test-tool/test_iscsi_cmdsn_toohigh.c
@@ -31,7 +31,7 @@ static int my_iscsi_queue_pdu(struct iscsi_context *iscsi, struct iscsi_pdu *pdu
 	switch (change_cmdsn) {
 	case 1:
 		/* change the cmdsn so it becomes too big */
-		*(uint32_t *)&pdu->outdata.data[24] = htonl(iscsi->maxcmdsn + 1);
+		scsi_set_uint32(&pdu->outdata.data[24], iscsi->maxcmdsn + 1);
 		/* fudge the cmdsn value back to where it should be if this
 		 * pdu is ignored.
 		 */

--- a/test-tool/test_iscsi_cmdsn_toolow.c
+++ b/test-tool/test_iscsi_cmdsn_toolow.c
@@ -31,7 +31,7 @@ static int my_iscsi_queue_pdu(struct iscsi_context *iscsi, struct iscsi_pdu *pdu
 	switch (change_cmdsn) {
 	case 1:
 		/* change the cmdsn so it becomes too big */
-		*(uint32_t *)&pdu->outdata.data[24] = htonl(iscsi->expcmdsn + 1);
+		scsi_set_uint32(&pdu->outdata.data[24], iscsi->expcmdsn + 1);
 		/* fudge the cmdsn value back to where it should be if this
 		 * pdu is ignored.
 		 */

--- a/test-tool/test_prin_read_keys_simple.c
+++ b/test-tool/test_prin_read_keys_simple.c
@@ -52,7 +52,7 @@ test_prin_read_keys_simple(void)
 	}
 
 	logging(LOG_VERBOSE, "Test ADDITIONAL_LENGTH matches DATA_IN size.");
-	al = ntohl(*(uint32_t *)&task->datain.data[4]);
+	al = scsi_get_uint32(&task->datain.data[4]);
 	if (al != task->datain.size - 8) {
 		logging(LOG_NORMAL,
 		    "[FAILED] ADDITIONAL_LENGTH was %d bytes but %d was expected.",


### PR DESCRIPTION
Fixes ARM problems too.  With this patch all ntohl/ntohs are finally
expunged from the SCSI code!

Signed-off-by: Paolo Bonzini pbonzini@redhat.com
