### PR TITLE
Ignore padding when an iovector is supplied

### DIFF
--- a/include/iscsi-private.h
+++ b/include/iscsi-private.h
@@ -269,6 +269,7 @@ struct scsi_task;
 void iscsi_pdu_set_cdb(struct iscsi_pdu *pdu, struct scsi_task *task);
 
 int iscsi_get_pdu_data_size(const unsigned char *hdr);
+int iscsi_get_pdu_padding_size(const unsigned char *hdr);
 int iscsi_process_pdu(struct iscsi_context *iscsi, struct iscsi_in_pdu *in);
 
 int iscsi_process_login_reply(struct iscsi_context *iscsi,

--- a/lib/pdu.c
+++ b/lib/pdu.c
@@ -230,9 +230,20 @@ iscsi_get_pdu_data_size(const unsigned char *hdr)
 	int size;
 
 	size = scsi_get_uint32(&hdr[4]) & 0x00ffffff;
-	size = (size+3) & 0xfffffffc;
 
 	return size;
+}
+
+
+int
+iscsi_get_pdu_padding_size(const unsigned char *hdr)
+{
+	int data_size, padded_size;
+
+	data_size = scsi_get_uint32(&hdr[4]) & 0x00ffffff;
+	padded_size = (data_size+3) & 0xfffffffc;
+
+	return padded_size - data_size;
 }
 
 enum iscsi_reject_reason {


### PR DESCRIPTION
The iSCSI protocol adds padding to a data packet if the data size is not
a multiple of four.  The iovector provided by QEMU does not include such
padding, and libiscsi then complains that there was a protocol error.
This patch fixes this by reading the padding in a separate "recv"
system call.  These packets anyway do not happen in the data path,
where the packet size is a multiple of 512.

This fixes QEMU's scsi-generic backend, which triggered the problem when
the target sent a 66-byte INQUIRY response.

Signed-off-by: Paolo Bonzini pbonzini@redhat.com
