### PR TITLE
Fix compilation issues under clang

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -43,9 +43,12 @@ lib_libiscsi_la_SOURCES += lib/md5.c
 endif
 
 SONAME=3
-SOREL=$(shell printf "%d%02d%02d" $(subst ., ,$(VERSION)))
+SOMAJOR = $(firstword $(version_split))
+SOMINOR = $(word 2, $(version_split))
+SOREVISION = $(word 3, $(version_split))
+SOREL = $(shell echo $(SOMINOR) + $(SOREVISION))
 lib_libiscsi_la_LDFLAGS = \
-	-version-info $(SONAME):$(SOREL):0 -bindir $(bindir) -no-undefined \
+	-version-info $(SONAME):$(SOMAJOR):$(SOREL) -bindir $(bindir) -no-undefined \
 	-export-symbols $(srcdir)/lib/libiscsi.syms
 
 # libiscsi utilities

--- a/include/iscsi-private.h
+++ b/include/iscsi-private.h
@@ -305,13 +305,13 @@ void iscsi_set_error(struct iscsi_context *iscsi, const char *error_string,
 struct scsi_iovector *iscsi_get_scsi_task_iovector_in(struct iscsi_context *iscsi, struct iscsi_in_pdu *in);
 struct scsi_iovector *iscsi_get_scsi_task_iovector_out(struct iscsi_context *iscsi, struct iscsi_pdu *pdu);
 
-inline void* iscsi_malloc(struct iscsi_context *iscsi, size_t size);
-inline void* iscsi_zmalloc(struct iscsi_context *iscsi, size_t size);
-inline void* iscsi_realloc(struct iscsi_context *iscsi, void* ptr, size_t size);
-inline void iscsi_free(struct iscsi_context *iscsi, void* ptr);
-inline char* iscsi_strdup(struct iscsi_context *iscsi, const char* str);
-inline void* iscsi_szmalloc(struct iscsi_context *iscsi, size_t size);
-inline void iscsi_sfree(struct iscsi_context *iscsi, void* ptr);
+void* iscsi_malloc(struct iscsi_context *iscsi, size_t size);
+void* iscsi_zmalloc(struct iscsi_context *iscsi, size_t size);
+void* iscsi_realloc(struct iscsi_context *iscsi, void* ptr, size_t size);
+void iscsi_free(struct iscsi_context *iscsi, void* ptr);
+char* iscsi_strdup(struct iscsi_context *iscsi, const char* str);
+void* iscsi_szmalloc(struct iscsi_context *iscsi, size_t size);
+void iscsi_sfree(struct iscsi_context *iscsi, void* ptr);
 
 unsigned long crc32c(char *buf, int len);
 

--- a/include/scsi-lowlevel.h
+++ b/include/scsi-lowlevel.h
@@ -1074,10 +1074,10 @@ EXTERN struct scsi_task *scsi_cdb_writeverify16(uint64_t lba, uint32_t xferlen, 
 
 void *scsi_malloc(struct scsi_task *task, size_t size);
 
-inline uint32_t scsi_get_uint32(const unsigned char *c);
-inline uint16_t scsi_get_uint16(const unsigned char *c);
-inline void scsi_set_uint32(unsigned char *c, uint32_t val);
-inline void scsi_set_uint16(unsigned char *c, uint16_t val);
+uint32_t scsi_get_uint32(const unsigned char *c);
+uint16_t scsi_get_uint16(const unsigned char *c);
+void scsi_set_uint32(unsigned char *c, uint32_t val);
+void scsi_set_uint16(unsigned char *c, uint16_t val);
 
 #ifdef __cplusplus
 }

--- a/lib/init.c
+++ b/lib/init.c
@@ -33,13 +33,13 @@
 #include "iscsi-private.h"
 #include "slist.h"
 
-inline void* iscsi_malloc(struct iscsi_context *iscsi, size_t size) {
+void* iscsi_malloc(struct iscsi_context *iscsi, size_t size) {
 	void * ptr = malloc(size);
 	if (ptr != NULL) iscsi->mallocs++;
 	return ptr;
 }
 
-inline void* iscsi_zmalloc(struct iscsi_context *iscsi, size_t size) {
+void* iscsi_zmalloc(struct iscsi_context *iscsi, size_t size) {
 	void * ptr = malloc(size);
 	if (ptr != NULL) {
 		memset(ptr,0x00,size);
@@ -48,7 +48,7 @@ inline void* iscsi_zmalloc(struct iscsi_context *iscsi, size_t size) {
 	return ptr;
 }
 
-inline void* iscsi_realloc(struct iscsi_context *iscsi, void* ptr, size_t size) {
+void* iscsi_realloc(struct iscsi_context *iscsi, void* ptr, size_t size) {
 	void * _ptr = realloc(ptr, size);
 	if (_ptr != NULL) {
 		iscsi->reallocs++;
@@ -56,19 +56,19 @@ inline void* iscsi_realloc(struct iscsi_context *iscsi, void* ptr, size_t size) 
 	return _ptr;
 }
 
-inline void iscsi_free(struct iscsi_context *iscsi, void* ptr) {
+void iscsi_free(struct iscsi_context *iscsi, void* ptr) {
 	if (ptr == NULL) return;
 	free(ptr);
 	iscsi->frees++;
 }
 
-inline char* iscsi_strdup(struct iscsi_context *iscsi, const char* str) {
+char* iscsi_strdup(struct iscsi_context *iscsi, const char* str) {
 	char *str2 = strdup(str);
 	if (str2 != NULL) iscsi->mallocs++;
 	return str2;
 }
 
-inline void* iscsi_szmalloc(struct iscsi_context *iscsi, size_t size) {
+void* iscsi_szmalloc(struct iscsi_context *iscsi, size_t size) {
 	void *ptr;
 	if (size > iscsi->smalloc_size) return NULL;
 	if (iscsi->smalloc_free > 0) {
@@ -81,7 +81,7 @@ inline void* iscsi_szmalloc(struct iscsi_context *iscsi, size_t size) {
 	return ptr;
 }
 
-inline void iscsi_sfree(struct iscsi_context *iscsi, void* ptr) {
+void iscsi_sfree(struct iscsi_context *iscsi, void* ptr) {
 	if (ptr == NULL) return;
 	if (iscsi->smalloc_free == SMALL_ALLOC_MAX_FREE) {
 		/* SMALL_ALLOC_MAX_FREE should be adjusted that this happens rarely */

--- a/lib/scsi-lowlevel.c
+++ b/lib/scsi-lowlevel.c
@@ -235,7 +235,7 @@ scsi_pr_type_str(enum scsi_persistent_out_type pr_type)
 	return value_string_find(pr_type_strings, pr_type);
 }
 
-inline uint64_t
+uint64_t
 scsi_get_uint64(const unsigned char *c)
 {
 	uint64_t val;
@@ -248,7 +248,7 @@ scsi_get_uint64(const unsigned char *c)
 	return val;
 }
 
-inline uint32_t
+uint32_t
 scsi_get_uint32(const unsigned char *c)
 {
 	uint32_t val;
@@ -259,7 +259,7 @@ scsi_get_uint32(const unsigned char *c)
 	return val;
 }
 
-inline uint16_t
+uint16_t
 scsi_get_uint16(const unsigned char *c)
 {
 	uint16_t val;
@@ -314,7 +314,7 @@ task_get_uint8(struct scsi_task *task, int offset)
 	}
 }
 
-inline void
+void
 scsi_set_uint64(unsigned char *c, uint64_t v)
 {
 	uint32_t val;
@@ -327,7 +327,7 @@ scsi_set_uint64(unsigned char *c, uint64_t v)
 	scsi_set_uint32(c, val);
 }
 
-inline void
+void
 scsi_set_uint32(unsigned char *c, uint32_t val)
 {
 	c[0] = val >> 24;
@@ -336,7 +336,7 @@ scsi_set_uint32(unsigned char *c, uint32_t val)
 	c[3] = val;
 }
 
-inline void
+void
 scsi_set_uint16(unsigned char *c, uint16_t val)
 {
 	c[0] = val >> 8;


### PR DESCRIPTION
clang defaults to c99 so remove inline statements( http://clang.llvm.org/compatibility.html#inline ) on functions sharedacross different translation units.
clang's linker doesn't like major numbers over 255 ( https://developer.apple.com/library/mac/documentation/Darwin/Reference/ManPages/man1/ld.1.html -current_version) so change how SOREL is generated in Makefile.am.
