### PR TITLE
Fix compilation on OS X

### DIFF
--- a/README
+++ b/README
@@ -159,6 +159,7 @@ Libiscsi has been tested on:
 * Windows (Win7-VisualStudio10)
 * OpenSolaris
 * Solaris 11 : Use "gmake" to build.
+* OS X
 
 RELEASE TARBALLS
 ================

--- a/lib/socket.c
+++ b/lib/socket.c
@@ -129,7 +129,7 @@ int set_tcp_sockopt(int sockfd, int optname, int value)
 {
 	int level;
 
-	#if defined(__FreeBSD__) || defined(__sun)
+	#if defined(__FreeBSD__) || defined(__sun) || (defined(__APPLE__) && defined(__MACH__))
 	struct protoent *buf;
 
 	if ((buf = getprotobyname("tcp")) != NULL)


### PR DESCRIPTION
OS X doesn't implement SOL_TCP so workaround this the same way as on FreeBSD/Solaris.

(Strictly speaking the clang patches are also required for compilation on modern OS X)
