### PR TITLE
Fix Makefile.am breakage.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -43,12 +43,13 @@ lib_libiscsi_la_SOURCES += lib/md5.c
 endif
 
 SONAME=3
+version_split = $(subst ., ,$(VERSION))
 SOMAJOR = $(firstword $(version_split))
 SOMINOR = $(word 2, $(version_split))
 SOREVISION = $(word 3, $(version_split))
-SOREL = $(shell echo $(SOMINOR) + $(SOREVISION))
+SOREL = $(shell echo $(SOMINOR) + $(SOREVISION) | bc)
 lib_libiscsi_la_LDFLAGS = \
-	-version-info $(SONAME):$(SOMAJOR):$(SOREL) -bindir $(bindir) -no-undefined \
+	-version-info $(SONAME):$(SOREL):0 -bindir $(bindir) -no-undefined \
 	-export-symbols $(srcdir)/lib/libiscsi.syms
 
 # libiscsi utilities


### PR DESCRIPTION
Commit 7692027 was somewhat raw and breaks the build. This commit finishes it off by adding the missing variable and setting the AGE to always be 0.

(From now on I'm testing whether my changes still work after a make distclean)
