### PR TITLE
Fix incorrect second initiator

### DIFF
--- a/test-tool/test_preventallow_2_itnexuses.c
+++ b/test-tool/test_preventallow_2_itnexuses.c
@@ -48,7 +48,7 @@ test_preventallow_2_itnexuses(void)
 	CU_ASSERT_EQUAL(ret, 0);
 
 	logging(LOG_VERBOSE, "Create a second connection to the target");
-	iscsic2 = iscsi_context_login(initiatorname1, tgt_url, &tgt_lun);
+	iscsic2 = iscsi_context_login(initiatorname2, tgt_url, &tgt_lun);
 	if (iscsic2 == NULL) {
 		logging(LOG_VERBOSE, "Failed to login to target");
 		return;

--- a/test-tool/test_reserve6_itnexus_loss.c
+++ b/test-tool/test_reserve6_itnexus_loss.c
@@ -46,7 +46,7 @@ test_reserve6_itnexus_loss(void)
 
 
 	logging(LOG_VERBOSE, "Create a second connection to the target");
-	iscsic2 = iscsi_context_login(initiatorname1, tgt_url, &tgt_lun);
+	iscsic2 = iscsi_context_login(initiatorname2, tgt_url, &tgt_lun);
 	if (iscsic2 == NULL) {
 		logging(LOG_VERBOSE, "Failed to login to target");
 		return;

--- a/test-tool/test_reserve6_logout.c
+++ b/test-tool/test_reserve6_logout.c
@@ -46,7 +46,7 @@ test_reserve6_logout(void)
 
 
 	logging(LOG_VERBOSE, "Create a second connection to the target");
-	iscsic2 = iscsi_context_login(initiatorname1, tgt_url, &tgt_lun);
+	iscsic2 = iscsi_context_login(initiatorname2, tgt_url, &tgt_lun);
 	if (iscsic2 == NULL) {
 		logging(LOG_VERBOSE, "Failed to login to target");
 		return;

--- a/test-tool/test_reserve6_lun_reset.c
+++ b/test-tool/test_reserve6_lun_reset.c
@@ -57,7 +57,7 @@ test_reserve6_lun_reset(void)
 
 
 	logging(LOG_VERBOSE, "Create a second connection to the target");
-	iscsic2 = iscsi_context_login(initiatorname1, tgt_url, &tgt_lun);
+	iscsic2 = iscsi_context_login(initiatorname2, tgt_url, &tgt_lun);
 	if (iscsic2 == NULL) {
 		logging(LOG_VERBOSE, "Failed to login to target");
 		return;

--- a/test-tool/test_reserve6_target_cold_reset.c
+++ b/test-tool/test_reserve6_target_cold_reset.c
@@ -56,7 +56,7 @@ test_reserve6_target_cold_reset(void)
 	sleep(3);
 
 	logging(LOG_VERBOSE, "Create a second connection to the target");
-	iscsic2 = iscsi_context_login(initiatorname1, tgt_url, &tgt_lun);
+	iscsic2 = iscsi_context_login(initiatorname2, tgt_url, &tgt_lun);
 	if (iscsic2 == NULL) {
 		logging(LOG_VERBOSE, "Failed to login to target");
 		return;

--- a/test-tool/test_reserve6_target_warm_reset.c
+++ b/test-tool/test_reserve6_target_warm_reset.c
@@ -57,7 +57,7 @@ test_reserve6_target_warm_reset(void)
 
 
 	logging(LOG_VERBOSE, "Create a second connection to the target");
-	iscsic2 = iscsi_context_login(initiatorname1, tgt_url, &tgt_lun);
+	iscsic2 = iscsi_context_login(initiatorname2, tgt_url, &tgt_lun);
 	if (iscsic2 == NULL) {
 		logging(LOG_VERBOSE, "Failed to login to target");
 		return;

--- a/test-tool/test_sanitize_readonly.c
+++ b/test-tool/test_sanitize_readonly.c
@@ -40,7 +40,7 @@ test_sanitize_readonly(void)
 	CHECK_FOR_DATALOSS;
 
 	logging(LOG_VERBOSE, "Create a second connection to the target");
-	iscsic2 = iscsi_context_login(initiatorname1, tgt_url, &tgt_lun);
+	iscsic2 = iscsi_context_login(initiatorname2, tgt_url, &tgt_lun);
 	if (iscsic2 == NULL) {
 		logging(LOG_VERBOSE, "Failed to login to target");
 		return;

--- a/test-tool/test_sanitize_reservations.c
+++ b/test-tool/test_sanitize_reservations.c
@@ -40,7 +40,7 @@ test_sanitize_reservations(void)
 	CHECK_FOR_DATALOSS;
 
 	logging(LOG_VERBOSE, "Create a second connection to the target");
-	iscsic2 = iscsi_context_login(initiatorname1, tgt_url, &tgt_lun);
+	iscsic2 = iscsi_context_login(initiatorname2, tgt_url, &tgt_lun);
 	if (iscsic2 == NULL) {
 		logging(LOG_VERBOSE, "Failed to login to target");
 		return;


### PR DESCRIPTION
Use the second initiator name in all files found by
ack "iscsic2 = "

I guess it could be the case that you would want the same initiator to connect to the same target twice (e.g. for multipath via different network addresses) but that case can be almost simulated by setting the second initiator name to be the same as the first.
