### PR TITLE
introduce LIBISCSI_API_VERSION

### DIFF
--- a/include/iscsi.h
+++ b/include/iscsi.h
@@ -33,6 +33,9 @@ extern "C" {
 struct iscsi_context;
 struct sockaddr;
 
+/* API VERSION */
+#define LIBISCSI_API_VERSION (20131020)
+
 /* FEATURES */
 #define LIBISCSI_FEATURE_IOVECTOR (1)
 #define LIBISCSI_FEATURE_NOP_COUNTER (1)


### PR DESCRIPTION
Hi Ronnie,

we introduced a lot of new features and even API changes in the last years. Since we have managed to break compatiblity recently I would like to introduce an API version indicated by the date to be able to check for via preprocessor macros in e.q. qemu.

Recently I had to cope with iscsi_get_lba_status not being present (I had to protect this by LIBISCSI_FEATURE_IOVECTOR...) and now I have to copy with iscsi_writesame16_task API being changed.

Please consider repackaging the 1.10 tarball so that we have it in there.

Thanks,
Peter
