### PR TITLE
fix CHAP authentication

### DIFF
--- a/lib/discovery.c
+++ b/lib/discovery.c
@@ -118,15 +118,8 @@ iscsi_process_text_reply(struct iscsi_context *iscsi, struct iscsi_pdu *pdu,
 			      pdu->private_data);
 		return -1;
 	}
-	if (size == 0) {
-		iscsi_set_error(iscsi, "size == 0 when parsing "
-				"discovery data");
-		pdu->callback(iscsi, SCSI_STATUS_ERROR, NULL,
-			      pdu->private_data);
-		return -1;
-	}
 
-	do {
+	while (size > 0) {
 		unsigned char *end;
 		int len;
 
@@ -204,7 +197,7 @@ iscsi_process_text_reply(struct iscsi_context *iscsi, struct iscsi_pdu *pdu,
 
 		ptr  += len + 1;
 		size -= len + 1;
-	} while (size > 0);
+	}
 
 	pdu->callback(iscsi, SCSI_STATUS_GOOD, targets, pdu->private_data);
 	iscsi_free_discovery_addresses(iscsi, targets);

--- a/lib/login.c
+++ b/lib/login.c
@@ -982,21 +982,13 @@ iscsi_process_login_reply(struct iscsi_context *iscsi, struct iscsi_pdu *pdu,
 		iscsi->expcmdsn = expcmdsn;
 	}
 
-	if (size == 0) {
-	       iscsi_set_error(iscsi, "size == 0 when parsing "
-			       "login data");
-	       pdu->callback(iscsi, SCSI_STATUS_ERROR, NULL,
-			     pdu->private_data);
-	       return -1;
-	}
-
 	/* XXX here we should parse the data returned in case the target
 	 * renegotiated some some parameters.
 	 *  we should also do proper handshaking if the target is not yet
 	 * prepared to transition to the next stage
 	 */
 
-	do {
+	while (size > 0) {
 		char *end;
 		int len;
 
@@ -1087,7 +1079,7 @@ iscsi_process_login_reply(struct iscsi_context *iscsi, struct iscsi_pdu *pdu,
 
 		ptr  += len + 1;
 		size -= len + 1;
-	} while (size > 0);
+	}
 
 	if (status == SCSI_STATUS_REDIRECT && iscsi->target_address[0]) {
 		ISCSI_LOG(iscsi, 2, "target requests redirect to %s",iscsi->target_address);


### PR DESCRIPTION
Empty discovery and login packets are legal, and have the same behavior
as packets with a single NUL in them.  Introduced by commit 94d73fc
(Merge pull request #83 from bonzini/coverity, 2013-11-05).

Reported-by: John Ferlan jferlan@redhat.com
Signed-off-by: Paolo Bonzini pbonzini@redhat.com

---

My apologies for the breakage. I tested only one target.
