### PR TITLE
OLD TESTS: Fix use after free in unsolicited_[non]immediate_data tests.

### DIFF
--- a/test-tool/1041_unsolicited_immediate_data.c
+++ b/test-tool/1041_unsolicited_immediate_data.c
@@ -93,6 +93,7 @@ int T1041_unsolicited_immediate_data(const char *initiator, const char *url)
 	 */ 	
 	printf("Login to target with IMMEDIATE_DATA=YES and INITIAL_R2T=YES ... ");
 	iscsi_destroy_context(iscsi);
+	iscsi_url->iscsi = NULL;
 	iscsi = iscsi_create_context(initiator);
 	iscsi_set_targetname(iscsi, iscsi_url->target);
 	iscsi_set_session_type(iscsi, ISCSI_SESSION_NORMAL);
@@ -154,8 +155,8 @@ int T1041_unsolicited_immediate_data(const char *initiator, const char *url)
 
 
 finished:
-	iscsi_destroy_context(iscsi);
 	iscsi_destroy_url(iscsi_url);
+	iscsi_destroy_context(iscsi);
 
 	return ret;
 }

--- a/test-tool/1042_unsolicited_nonimmediate_data.c
+++ b/test-tool/1042_unsolicited_nonimmediate_data.c
@@ -110,6 +110,7 @@ int T1042_unsolicited_nonimmediate_data(const char *initiator, const char *url)
 	 */ 	
 	printf("Login to target with IMMEDIATE_DATA=NO and INITIAL_R2T=NO ... ");
 	iscsi_destroy_context(iscsi);
+	iscsi_url->iscsi = NULL;
 	iscsi = iscsi_create_context(initiator);
 	iscsi_set_targetname(iscsi, iscsi_url->target);
 	iscsi_set_session_type(iscsi, ISCSI_SESSION_NORMAL);
@@ -172,8 +173,8 @@ int T1042_unsolicited_nonimmediate_data(const char *initiator, const char *url)
 
 
 finished:
-	iscsi_destroy_context(iscsi);
 	iscsi_destroy_url(iscsi_url);
+	iscsi_destroy_context(iscsi);
 
 	return ret;
 }


### PR DESCRIPTION
After destroying iscsi, nullify iscsi_url's reference to it to prevent a use after free.
Also some harmless reordering so iscsi_url is destroyed before iscsi is.

Detected by clang's AddressSanitizer.
