### PR TITLE
Fix READ(6) tests' capacity checks

### DIFF
--- a/test-tool/test_read6_beyond_eol.c
+++ b/test-tool/test_read6_beyond_eol.c
@@ -29,7 +29,7 @@ test_read6_beyond_eol(void)
 { 
 	int i, ret;
 
-	if (num_blocks >= 0x1fffff) {
+	if (num_blocks > 0x1fffff) {
 		CU_PASS("LUN is too big for read-beyond-eol tests with READ6. Skipping test.\n");
 		return;
 	}

--- a/test-tool/test_read6_simple.c
+++ b/test-tool/test_read6_simple.c
@@ -46,7 +46,7 @@ test_read6_simple(void)
 
 
 	logging(LOG_VERBOSE, "Test READ6 of 1-255 blocks at the end of the LUN");
-	if (num_blocks >= 0x1fffff) {
+	if (num_blocks > 0x200000) {
 		CU_PASS("LUN is too big for read-at-eol tests with READ6. Skipping test.\n");
 	} else {
 		for (i = 1; i <= 255; i++) {


### PR DESCRIPTION
test_read6_simple.c does a check on LUN size:

``` C
    if (num_blocks >= 0x1fffff) {
        CU_PASS("LUN is too big for read-beyond-eol tests with READ6. Skipping test.\n");
        return;
    }
```

but if I understand correctly, a 1 GiB volume should have exactly 0x200000 blocks. The read-beyond-eol test also has a similar check that would skip the rest of the test if the volume has exactly 0x1fffff blocks. In this case, I believe it should run...

Patch attached.
