### PR TITLE
libiscsi: fix dangling pointer for outqueue_current

### DIFF
--- a/lib/pdu.c
+++ b/lib/pdu.c
@@ -147,6 +147,10 @@ iscsi_free_pdu(struct iscsi_context *iscsi, struct iscsi_pdu *pdu)
 	}
 	pdu->indata.data = NULL;
 
+	if (iscsi->outqueue_current == pdu) {
+		iscsi->outqueue_current = NULL;
+	}
+
 	iscsi_sfree(iscsi, pdu);
 }
 


### PR DESCRIPTION
Ronnie, I'm not 100% sure this is the right fix. Perhaps @plieven can help reviewing too.

The outqueue_current PDU might also be in waitpdu if it does not have ISCSI_PDU_DELETE_WHEN_SENT.  outqueue_current is freed after the waitpdu list (for reconnect or defer_reconnect), or sometimes not considered at all (for cancel), and this can cause a dangling pointer.

Keep outqueue_current up to date when a PDU is freed.  A bit hacky, but it avoids touching code all over the place.
