### PR TITLE
- test_unmap_simple: was assuming that zero buffer was already cleared, ...

### DIFF
--- a/test-tool/test_unmap_simple.c
+++ b/test-tool/test_unmap_simple.c
@@ -43,6 +43,7 @@ test_unmap_simple(void)
 	struct unmap_list list[257];
 	unsigned char *buf = alloca(256 * block_size);
 	unsigned char *zbuf = alloca(256 * block_size);
+        memset(zbuf, 0, 256 * block_size);
 
 	logging(LOG_VERBOSE, LOG_BLANK_LINE);
 	logging(LOG_VERBOSE, "Test basic UNMAP");

--- a/test-tool/test_writesame10_unmap_until_end.c
+++ b/test-tool/test_writesame10_unmap_until_end.c
@@ -28,13 +28,17 @@
 void
 test_writesame10_unmap_until_end(void)
 {
-	int i, ret;
-	unsigned int j;
+	int ret;
+	unsigned int i, j;
+	unsigned char *zeroBlock;
 
 	CHECK_FOR_DATALOSS;
 	CHECK_FOR_THIN_PROVISIONING;
 	CHECK_FOR_LBPWS10;
 	CHECK_FOR_SBC;
+
+	zeroBlock = malloc(block_size);
+	memset(zeroBlock, 0, block_size);
 
 	logging(LOG_VERBOSE, LOG_BLANK_LINE);
 	logging(LOG_VERBOSE, "Test WRITESAME10 of 1-256 blocks at the end of the LUN by setting number-of-blocks==0");
@@ -63,10 +67,8 @@ test_writesame10_unmap_until_end(void)
 			ret = read10(iscsic, tgt_lun, num_blocks - i,
 				     i * block_size, block_size,
 				     0, 0, 0, 0, 0, buf);
-			for (j = 0; j < block_size * i; j++) {
-				if (buf[j] != 0) {
-					CU_ASSERT_EQUAL(buf[j], 0);
-				}
+			for (j = 0; j < i; j++) {
+				CU_ASSERT_EQUAL(memcmp(buf + j*block_size, zeroBlock, block_size), 0);
 			}
 		} else {
 			logging(LOG_VERBOSE, "LBPRZ is clear. Skip the read "
@@ -74,4 +76,5 @@ test_writesame10_unmap_until_end(void)
 		}
 		free(buf);
 	}
+	free(zeroBlock);
 }

--- a/test-tool/test_writesame16_unmap.c
+++ b/test-tool/test_writesame16_unmap.c
@@ -28,9 +28,10 @@
 void
 test_writesame16_unmap(void)
 {
-	int i, ret;
-	unsigned int j;
+	int ret;
+	unsigned int i, j;
 	unsigned char *buf;
+	unsigned char *zeroBlock;
 
 	CHECK_FOR_DATALOSS;
 	CHECK_FOR_THIN_PROVISIONING;
@@ -40,6 +41,8 @@ test_writesame16_unmap(void)
 	logging(LOG_VERBOSE, LOG_BLANK_LINE);
 	logging(LOG_VERBOSE, "Test WRITESAME16 of 1-256 blocks at the start of the LUN");
 	buf = malloc(65536 * block_size);
+	zeroBlock = malloc(block_size);
+	memset(zeroBlock, 0, block_size);
 	for (i = 1; i <= 256; i++) {
 		logging(LOG_VERBOSE, "Write %d blocks of 0xFF", i);
 		memset(buf, 0xff, i * block_size);
@@ -67,10 +70,8 @@ test_writesame16_unmap(void)
 			ret = read16(iscsic, tgt_lun, 0,
 				     i * block_size, block_size,
 				     0, 0, 0, 0, 0, buf);
-			for (j = 0; j < block_size * i; j++) {
-				if (buf[j] != 0) {
-					CU_ASSERT_EQUAL(buf[j], 0);
-				}
+			for (j = 0; j < i; j++) {
+				CU_ASSERT_EQUAL(memcmp(buf + j*block_size, zeroBlock, block_size), 0);
 			}
 		} else {
 			logging(LOG_VERBOSE, "LBPRZ is clear. Skip the read "
@@ -103,10 +104,8 @@ test_writesame16_unmap(void)
 			ret = read16(iscsic, tgt_lun, num_blocks - i,
 				     i * block_size, block_size,
 				     0, 0, 0, 0, 0, buf);
-			for (j = 0; j < block_size * i; j++) {
-				if (buf[j] != 0) {
-					CU_ASSERT_EQUAL(buf[j], 0);
-				}
+			for (j = 0; j < i; j++) {
+				CU_ASSERT_EQUAL(memcmp(buf + j*block_size, zeroBlock, block_size), 0);
 			}
 		} else {
 			logging(LOG_VERBOSE, "LBPRZ is clear. Skip the read "
@@ -176,10 +175,8 @@ test_writesame16_unmap(void)
 			ret = read16(iscsic, tgt_lun, 0,
 				i * block_size, block_size,
 				0, 0, 0, 0, 0, buf);
-			for (j = 0; j < block_size * i; j++) {
-				if (buf[j] != 0) {
-					CU_ASSERT_EQUAL(buf[j], 0);
-				}
+			for (j = 0; j < i; j++) {
+				CU_ASSERT_EQUAL(memcmp(buf + j*block_size, zeroBlock, block_size), 0);
 			}
 		} else {
 			logging(LOG_VERBOSE, "LBPRZ is clear. Skip the read "
@@ -228,10 +225,8 @@ test_writesame16_unmap(void)
 			ret = read16(iscsic, tgt_lun, 0,
 				i * block_size, block_size,
 				0, 0, 0, 0, 0, buf);
-			for (j = 0; j < block_size * i; j++) {
-				if (buf[j] != 0) {
-					CU_ASSERT_EQUAL(buf[j], 0);
-				}
+			for (j = 0; j < i; j++) {
+				CU_ASSERT_EQUAL(memcmp(buf + j*block_size, zeroBlock, block_size), 0);
 			}
 		} else {
 			logging(LOG_VERBOSE, "LBPRZ is clear. Skip the read "
@@ -251,4 +246,5 @@ test_writesame16_unmap(void)
 
 finished:
 	free(buf);
+	free(zeroBlock);
 }

--- a/test-tool/test_writesame16_unmap_until_end.c
+++ b/test-tool/test_writesame16_unmap_until_end.c
@@ -29,14 +29,18 @@
 void
 test_writesame16_unmap_until_end(void)
 {
-	int i, ret;
-	unsigned int j;
+	int ret;
+	unsigned int i, j;
 	unsigned char *buf = alloca(256 * block_size);
+	unsigned char *zeroBlock;
 
 	CHECK_FOR_DATALOSS;
 	CHECK_FOR_THIN_PROVISIONING;
 	CHECK_FOR_LBPWS;
 	CHECK_FOR_SBC;
+
+	zeroBlock = malloc(block_size);
+	memset(zeroBlock, 0, block_size);
 
 	logging(LOG_VERBOSE, LOG_BLANK_LINE);
 	logging(LOG_VERBOSE, "Test WRITESAME16 of 1-256 blocks at the end of the LUN by setting number-of-blocks==0");
@@ -67,14 +71,13 @@ test_writesame16_unmap_until_end(void)
 			ret = read16(iscsic, tgt_lun, num_blocks - i,
 				     i * block_size, block_size,
 				     0, 0, 0, 0, 0, buf);
-			for (j = 0; j < block_size * i; j++) {
-				if (buf[j] != 0) {
-					CU_ASSERT_EQUAL(buf[j], 0);
-				}
+			for (j = 0; j < i; j++) {
+				CU_ASSERT_EQUAL(memcmp(buf + j*block_size, zeroBlock, block_size), 0);
 			}
 		} else {
 			logging(LOG_VERBOSE, "LBPRZ is clear. Skip the read "
 				"and verify zero test");
 		}
 	}
+	free(zeroBlock);
 }


### PR DESCRIPTION
...which is not guaranteed and resulted in spurious failures
- writesame10_unmap_until_end, writesame16_unmap, writesame16_unmap_until_end were doing an CU_ASSERT _PER-BYTE_ in the verification phase,
  which was very CPU-intensive. This change uses memcmp on a whole block which finishes much quicker.
