### PR TITLE
bump ABI version again

### DIFF
--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -10,9 +10,9 @@ if !HAVE_LIBGCRYPT
 libiscsi_la_SOURCES += md5.c
 endif
 
-SOCURRENT=3
+SOCURRENT=4
 SOREVISON=11
-SOAGE=1
+SOAGE=0
 libiscsi_la_LDFLAGS = \
 	-version-info $(SOCURRENT):$(SOREVISON):$(SOAGE) -bindir $(bindir) \
 	-no-undefined -export-symbols libiscsi.syms


### PR DESCRIPTION
1.10 and 1.11 both introduced incompatible changes to the
libiscsi ABI.  Please do not do that, and feel free to Cc
me on any patch that touches include/.  In the meanwhile,
bump the soname of the library.  I suggest releasing 1.11.1
with this change for distros.

Signed-off-by: Paolo Bonzini pbonzini@redhat.com
