### PR TITLE
pdu: check callback on iscsi_process_reject

### DIFF
--- a/lib/pdu.c
+++ b/lib/pdu.c
@@ -350,8 +350,10 @@ int iscsi_process_reject(struct iscsi_context *iscsi,
 		return -1;
 	}
 
-	pdu->callback(iscsi, SCSI_STATUS_ERROR, NULL,
-			      pdu->private_data);
+	if (pdu->callback) {
+		pdu->callback(iscsi, SCSI_STATUS_ERROR, NULL,
+					pdu->private_data);
+	}
 
 	ISCSI_LIST_REMOVE(&iscsi->waitpdu, pdu);
 	iscsi_free_pdu(iscsi, pdu);


### PR DESCRIPTION
if the rejected packet is a NOP-Out it is legal
that it has no callback. In this case we end
up in a segfault.

Signed-off-by: Peter Lieven pl@kamp.de
