### PR TITLE
iscsi_which_events: do not set POLLOUT if context is corked

### DIFF
--- a/lib/socket.c
+++ b/lib/socket.c
@@ -383,8 +383,10 @@ iscsi_which_events(struct iscsi_context *iscsi)
 {
 	int events = iscsi->is_connected ? POLLIN : POLLOUT;
 
-	if (iscsi->outqueue_current != NULL || (iscsi->outqueue != NULL && iscsi_serial32_compare(iscsi->outqueue->cmdsn, iscsi->maxcmdsn) <= 0)) {
-	 	events |= POLLOUT;
+	if (iscsi->outqueue_current != NULL ||
+	    (iscsi->outqueue != NULL && !iscsi->is_corked &&
+	     iscsi_serial32_compare(iscsi->outqueue->cmdsn, iscsi->maxcmdsn) <= 0)) {
+		events |= POLLOUT;
 	}
 	return events;
 }


### PR DESCRIPTION
if the socket is corked we otherwise set POLLOUT and then
do not sent. Depending on the event loop implementation this
can result in a busy wait.

Signed-off-by: Peter Lieven pl@kamp.de
