### PR TITLE
Add ULL suffix to large integer literals

### DIFF
--- a/test-tool/test_get_lba_status_beyond_eol.c
+++ b/test-tool/test_get_lba_status_beyond_eol.c
@@ -42,11 +42,11 @@ test_get_lba_status_beyond_eol(void)
 
 	logging(LOG_VERBOSE, "Test GET_LBA_STATUS at LBA 2^63");
 
-	ret = get_lba_status_lbaoutofrange(iscsic, tgt_lun, 0x8000000000000000, 24);
+	ret = get_lba_status_lbaoutofrange(iscsic, tgt_lun, 0x8000000000000000ULL, 24);
 	CU_ASSERT_EQUAL(ret, 0);
 
 	logging(LOG_VERBOSE, "Test GET_LBA_STATUS at LBA -1");
 
-	ret = get_lba_status_lbaoutofrange(iscsic, tgt_lun, 0xffffffffffffffff, 24);
+	ret = get_lba_status_lbaoutofrange(iscsic, tgt_lun, 0xffffffffffffffffULL, 24);
 	CU_ASSERT_EQUAL(ret, 0);
 }

--- a/test-tool/test_orwrite_0blocks.c
+++ b/test-tool/test_orwrite_0blocks.c
@@ -51,7 +51,7 @@ test_orwrite_0blocks(void)
 
 
 	logging(LOG_VERBOSE, "Test ORWRITE 0-blocks at LBA==2^63");
-	ret = orwrite_lbaoutofrange(iscsic, tgt_lun, 0x8000000000000000,
+	ret = orwrite_lbaoutofrange(iscsic, tgt_lun, 0x8000000000000000ULL,
 				    0, block_size,
 				    0, 0, 0, 0, 0, NULL);
 	CU_ASSERT_EQUAL(ret, 0);

--- a/test-tool/test_orwrite_beyond_eol.c
+++ b/test-tool/test_orwrite_beyond_eol.c
@@ -59,7 +59,7 @@ test_orwrite_beyond_eol(void)
 			break;
 		}
 		ret = orwrite_lbaoutofrange(iscsic, tgt_lun,
-					    0x8000000000000000,
+					    0x8000000000000000ULL,
 					    i * block_size, block_size,
 					    0, 0, 0, 0, 0, buf);
 		CU_ASSERT_EQUAL(ret, 0);

--- a/test-tool/test_prefetch16_0blocks.c
+++ b/test-tool/test_prefetch16_0blocks.c
@@ -46,7 +46,7 @@ test_prefetch16_0blocks(void)
 
 
 	logging(LOG_VERBOSE, "Test PREFETCH16 0-blocks at LBA==2^63");
-	ret = prefetch16_lbaoutofrange(iscsic, tgt_lun, 0x8000000000000000,
+	ret = prefetch16_lbaoutofrange(iscsic, tgt_lun, 0x8000000000000000ULL,
 				       0, 0, 0);
 	CU_ASSERT_EQUAL(ret, 0);
 

--- a/test-tool/test_prefetch16_beyond_eol.c
+++ b/test-tool/test_prefetch16_beyond_eol.c
@@ -45,7 +45,7 @@ test_prefetch16_beyond_eol(void)
 
 	logging(LOG_VERBOSE, "Test PREFETCH16 1-256 blocks at LBA==2^63");
 	for (i = 1; i <= 256; i++) {
-		ret = prefetch16_lbaoutofrange(iscsic, tgt_lun, 0x8000000000000000,
+		ret = prefetch16_lbaoutofrange(iscsic, tgt_lun, 0x8000000000000000ULL,
 					       i, 0, 0);
 		CU_ASSERT_EQUAL(ret, 0);
 	}

--- a/test-tool/test_read16_0blocks.c
+++ b/test-tool/test_read16_0blocks.c
@@ -48,7 +48,7 @@ test_read16_0blocks(void)
 
 
 	logging(LOG_VERBOSE, "Test READ16 0-blocks at LBA==2^63");
-	ret = read16_lbaoutofrange(iscsic, tgt_lun, 0x8000000000000000, 0,
+	ret = read16_lbaoutofrange(iscsic, tgt_lun, 0x8000000000000000ULL, 0,
 				   block_size, 0, 0, 0, 0, 0, NULL);
 	CU_ASSERT_EQUAL(ret, 0);
 

--- a/test-tool/test_read16_beyond_eol.c
+++ b/test-tool/test_read16_beyond_eol.c
@@ -67,7 +67,7 @@ test_read16_beyond_eol(void)
 			break;
 		}
 
-		ret = read16_lbaoutofrange(iscsic, tgt_lun, 0x8000000000000000,
+		ret = read16_lbaoutofrange(iscsic, tgt_lun, 0x8000000000000000ULL,
 					   i * block_size, block_size,
 					   0, 0, 0, 0, 0, NULL);
 		CU_ASSERT_EQUAL(ret, 0);

--- a/test-tool/test_verify16_0blocks.c
+++ b/test-tool/test_verify16_0blocks.c
@@ -46,7 +46,7 @@ test_verify16_0blocks(void)
 
 
 	logging(LOG_VERBOSE, "Test VERIFY16 0-blocks at LBA==2^63");
-	ret = verify16_lbaoutofrange(iscsic, tgt_lun, 0x8000000000000000, 0,
+	ret = verify16_lbaoutofrange(iscsic, tgt_lun, 0x8000000000000000ULL, 0,
 				   block_size, 0, 0, 1, NULL);
 	CU_ASSERT_EQUAL(ret, 0);
 

--- a/test-tool/test_verify16_beyond_eol.c
+++ b/test-tool/test_verify16_beyond_eol.c
@@ -57,7 +57,7 @@ test_verify16_beyond_eol(void)
 			break;
 		}
 
-		ret = verify16_lbaoutofrange(iscsic, tgt_lun, 0x8000000000000000,
+		ret = verify16_lbaoutofrange(iscsic, tgt_lun, 0x8000000000000000ULL,
 					   i * block_size, block_size,
 					   0, 0, 1, buf);
 		CU_ASSERT_EQUAL(ret, 0);

--- a/test-tool/test_write16_0blocks.c
+++ b/test-tool/test_write16_0blocks.c
@@ -49,7 +49,7 @@ test_write16_0blocks(void)
 
 
 	logging(LOG_VERBOSE, "Test WRITE16 0-blocks at LBA==2^63");
-	ret = write16_lbaoutofrange(iscsic, tgt_lun, 0x8000000000000000, 0,
+	ret = write16_lbaoutofrange(iscsic, tgt_lun, 0x8000000000000000ULL, 0,
 				    block_size, 0, 0, 0, 0, 0, NULL);
 	CU_ASSERT_EQUAL(ret, 0);
 

--- a/test-tool/test_write16_beyond_eol.c
+++ b/test-tool/test_write16_beyond_eol.c
@@ -59,7 +59,7 @@ test_write16_beyond_eol(void)
 		if (maximum_transfer_length && maximum_transfer_length < i) {
 			break;
 		}
-		ret = write16_lbaoutofrange(iscsic, tgt_lun, 0x8000000000000000,
+		ret = write16_lbaoutofrange(iscsic, tgt_lun, 0x8000000000000000ULL,
 					   i * block_size, block_size,
 					   0, 0, 0, 0, 0, buf);
 		CU_ASSERT_EQUAL(ret, 0);

--- a/test-tool/test_writesame16_0blocks.c
+++ b/test-tool/test_writesame16_0blocks.c
@@ -61,7 +61,7 @@ test_writesame16_0blocks(void)
 
 
 	logging(LOG_VERBOSE, "Test WRITESAME16 0-blocks at LBA==2^63");
-	ret = writesame16_lbaoutofrange(iscsic, tgt_lun, 0x8000000000000000,
+	ret = writesame16_lbaoutofrange(iscsic, tgt_lun, 0x8000000000000000ULL,
 					block_size, inq_bl->wsnz,
 					0, 0, 0, 0, NULL);
 	CU_ASSERT_EQUAL(ret, 0);

--- a/test-tool/test_writesame16_beyond_eol.c
+++ b/test-tool/test_writesame16_beyond_eol.c
@@ -52,7 +52,7 @@ test_writesame16_beyond_eol(void)
 
 	logging(LOG_VERBOSE, "Test WRITESAME16 1-256 blocks at LBA==2^63");
 	for (i = 1; i <= 256; i++) {
-		ret = writesame16_lbaoutofrange(iscsic, tgt_lun, 0x8000000000000000,
+		ret = writesame16_lbaoutofrange(iscsic, tgt_lun, 0x8000000000000000ULL,
 						block_size, i,
 						0, 0, 0, 0, buf);
 		CU_ASSERT_EQUAL(ret, 0);

--- a/test-tool/test_writeverify16_0blocks.c
+++ b/test-tool/test_writeverify16_0blocks.c
@@ -51,7 +51,7 @@ test_writeverify16_0blocks(void)
 
 
 	logging(LOG_VERBOSE, "Test WRITEVERIFY16 0-blocks at LBA==2^63");
-	ret = writeverify16_lbaoutofrange(iscsic, tgt_lun, 0x8000000000000000,
+	ret = writeverify16_lbaoutofrange(iscsic, tgt_lun, 0x8000000000000000ULL,
 					  0, block_size,
 					  0, 0, 0, 0, NULL);
 	CU_ASSERT_EQUAL(ret, 0);

--- a/test-tool/test_writeverify16_beyond_eol.c
+++ b/test-tool/test_writeverify16_beyond_eol.c
@@ -61,7 +61,7 @@ test_writeverify16_beyond_eol(void)
 		}
 
 		ret = writeverify16_lbaoutofrange(iscsic, tgt_lun,
-						  0x8000000000000000,
+						  0x8000000000000000ULL,
 						  i * block_size, block_size,
 						  0, 0, 0, 0, buf);
 		CU_ASSERT_EQUAL(ret, 0);


### PR DESCRIPTION
When trying to compile libiscsi on a 32 bit Ubuntu 10.04 with gcc 4.4.3
errors like the following are produced:

test_get_lba_status_beyond_eol.c:45: error: integer constant is too
large for ‘long’ type

This is because we don't specify that we are explictly compiling to the
c99 standard and as such gcc defaults to gnu90 standard. This in turn
means the maximum default type of integer literals is unsigned long int
which not big enough to hold the literal on a 32 bit architecture.

Fix this by adding the ULL suffix to all large integer literals.

Signed-off-by: Sitsofe Wheeler sitsofe@yahoo.com
