### PR TITLE
pdu: add workaround for DELL Equallogic FW bugs 71409 & 73732

### DIFF
--- a/lib/pdu.c
+++ b/lib/pdu.c
@@ -432,6 +432,15 @@ iscsi_process_pdu(struct iscsi_context *iscsi, struct iscsi_in_pdu *in)
 		switch (event) {
 		case 0x1:
 			ISCSI_LOG(iscsi, 2, "target requests logout within %u seconds", param3);
+			/* this is an ugly workaround for DELL Equallogic FW 7.x bugs:
+			 *  Bug_71409 - I/O errors during volume move (present before 7.0.7)
+			 *  Bug_73732 - I/O errors during volume move operation (still present in 7.0.9)
+			 */
+			if (getenv("LIBISCSI_DROP_CONN_ON_ASYNC_EVENT1") != NULL) {
+				 
+				ISCSI_LOG(iscsi, 2, "dropping connection to fix errors with broken DELL Equallogic firmware 7.x");
+				return -1;
+			}
 			iscsi_logout_async_internal(iscsi, iscsi_reconnect_after_logout, NULL, ISCSI_PDU_DROP_ON_RECONNECT|ISCSI_PDU_URGENT_DELIVERY);
 			return 0;
 		case 0x2:


### PR DESCRIPTION
Dell Equallogic storages may redirect connections from one member of a multi member storage
group to another. When the member that has the volume lead changes the storage issues
an async disconnect request message. The correct behaviour would be to either fail all I/O requests
with a check condition (waiting for logout) or fullfil requests until the time specified
in the disconnect request message has elapsed and then drop the connection. In firwamre 7.x
however the storage sometimes cancels requests with SENSE KEY:ILLEGAL_REQUEST(5)
ASCQ:LOGICAL_UNIT_NOT_SUPPORTED(0x2500). This leads to I/O errors propagated to the application.
This patch was reported in May 2014 to Dell and the initial bug 71409 has been fixed in 7.0.7.
However, the first fix did not entirely solve the problem and bug 73732 has been raised.

This patch adds an environment variable LIBISCSI_DROP_CONN_ON_ASYNC_EVENT1 which if set leads
to an immediate drop of the connection when such an async event is received. This is ugly, but
works around the I/O errors.

Signed-off-by: Peter Lieven pl@kamp.de
