### PR TITLE
iscsi-command: fix unsolicited data-out length

### DIFF
--- a/include/iscsi-private.h
+++ b/include/iscsi-private.h
@@ -33,6 +33,13 @@ extern "C" {
 #define discard_const(ptr) ((void *)((intptr_t)(ptr)))
 #endif
 
+#ifndef MIN
+#define MIN(a, b) (((a) < (b)) ? (a) : (b))
+#endif
+#ifndef MAX
+#define MAX(a, b) (((a) > (b)) ? (a) : (b))
+#endif
+
 #define ISCSI_RAW_HEADER_SIZE			48
 #define ISCSI_DIGEST_SIZE			 4
 

--- a/lib/init.c
+++ b/lib/init.c
@@ -179,13 +179,9 @@ iscsi_create_context(const char *initiator_name)
 	/* iscsi->smalloc_size is the size for small allocations. this should be
 	   max(ISCSI_HEADER_SIZE, sizeof(struct iscsi_pdu), sizeof(struct iscsi_in_pdu))
 	   rounded up to the next power of 2. */
+	required = MAX(required, sizeof(struct iscsi_pdu));
+	required = MAX(required, sizeof(struct iscsi_in_pdu));
 	iscsi->smalloc_size = 1;
-	if (sizeof(struct iscsi_pdu) > required) {
-		required = sizeof(struct iscsi_pdu);
-	}
-	if (sizeof(struct iscsi_in_pdu) > required) {
-		required = sizeof(struct iscsi_in_pdu);
-	}
 	while (iscsi->smalloc_size < required) {
 		iscsi->smalloc_size <<= 1;
 	}

--- a/lib/iscsi-command.c
+++ b/lib/iscsi-command.c
@@ -76,9 +76,7 @@ iscsi_send_data_out(struct iscsi_context *iscsi, struct iscsi_pdu *cmd_pdu,
 		struct iscsi_pdu *pdu;
 		int flags;
 
-		if (len > iscsi->target_max_recv_data_segment_length) {
-			len = iscsi->target_max_recv_data_segment_length;
-		}
+		len = MIN(len, iscsi->target_max_recv_data_segment_length);
 
 		pdu = iscsi_allocate_pdu_with_itt_flags(iscsi, ISCSI_PDU_DATA_OUT,
 				 ISCSI_PDU_NO_PDU,
@@ -269,13 +267,8 @@ iscsi_scsi_command_async(struct iscsi_context *iscsi, int lun,
 		if (iscsi->use_immediate_data == ISCSI_IMMEDIATE_DATA_YES) {
 			uint32_t len = task->expxferlen;
 
-			if (len > iscsi->first_burst_length) {
-				len = iscsi->first_burst_length;
-			}
-
-			if (len > iscsi->target_max_recv_data_segment_length) {
-				len = iscsi->target_max_recv_data_segment_length;
-			}
+			len = MIN(len, iscsi->first_burst_length);
+			len = MIN(len, iscsi->target_max_recv_data_segment_length);
 
 			pdu->payload_offset = 0;
 			pdu->payload_len    = len;

--- a/lib/iscsi-command.c
+++ b/lib/iscsi-command.c
@@ -193,11 +193,8 @@ iscsi_timeout_scan(struct iscsi_context *iscsi)
 int
 iscsi_send_unsolicited_data_out(struct iscsi_context *iscsi, struct iscsi_pdu *pdu)
 {
-	uint32_t len = pdu->expxferlen - pdu->payload_len;
+	uint32_t len = MIN(pdu->expxferlen, iscsi->first_burst_length) - pdu->payload_len;
 
-	if (len > iscsi->first_burst_length) {
-		len = iscsi->first_burst_length;
-	}
 	return iscsi_send_data_out(iscsi, pdu, 0xffffffff,
 				   pdu->payload_len, len);
 }


### PR DESCRIPTION
the recent implementation allows to send
iscsi->first_burst_length + iscsi->target_max_recv_data_segment_length
bytes if immediate and unsolicited data-out is send and
iscsi->target_max_recv_data_segment_length < iscsi->first_burst_length.

RFC3720 defines the length as:

Length=(min(FirstBurstLength, Expected Data
   Transfer Length) - Received Immediate Data Length).

so that immediate data and unsolicited data-out are together
FirstBurstLength at maximum.