### PR TITLE
Iscsi perf clang

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -128,6 +128,9 @@ AC_CHECK_MEMBER([struct CU_SuiteInfo.pSetUpFunc],
 #include <CUnit/TestDB.h>
 ]])
 
+AC_SEARCH_LIBS(clock_gettime, rt, [
+	       AC_DEFINE([HAVE_CLOCK_GETTIME],1,[Define if clock_gettime is available])])
+
 
 AC_CONFIG_FILES([Makefile]
 		[lib/Makefile]

--- a/test-tool/test_preventallow_cold_reset.c
+++ b/test-tool/test_preventallow_cold_reset.c
@@ -61,7 +61,8 @@ test_preventallow_cold_reset(void)
 	logging(LOG_VERBOSE, "Perform cold reset on target");
 	ret = iscsi_task_mgmt_target_cold_reset_sync(sd->iscsi_ctx);
 	logging(LOG_VERBOSE, "Wait until all unit attentions clear");
-	while (testunitready(sd, EXPECT_STATUS_GOOD) != 0);
+	while (testunitready(sd, EXPECT_STATUS_GOOD) != 0)
+		;
 	CU_ASSERT_EQUAL(ret, 0);
 
 

--- a/test-tool/test_preventallow_lun_reset.c
+++ b/test-tool/test_preventallow_lun_reset.c
@@ -62,7 +62,8 @@ test_preventallow_lun_reset(void)
 	ret = iscsi_task_mgmt_lun_reset_sync(sd->iscsi_ctx, sd->iscsi_lun);
 	CU_ASSERT_EQUAL(ret, 0);
 	logging(LOG_VERBOSE, "Wait until all unit attentions clear");
-	while (testunitready(sd, EXPECT_STATUS_GOOD) != 0);
+	while (testunitready(sd, EXPECT_STATUS_GOOD) != 0)
+		;
 
 
 	logging(LOG_VERBOSE, "Try to eject the medium");

--- a/test-tool/test_preventallow_warm_reset.c
+++ b/test-tool/test_preventallow_warm_reset.c
@@ -62,7 +62,8 @@ test_preventallow_warm_reset(void)
 	ret = iscsi_task_mgmt_target_warm_reset_sync(sd->iscsi_ctx);
 	CU_ASSERT_EQUAL(ret, 0);
 	logging(LOG_VERBOSE, "Wait until all unit attentions clear");
-	while (testunitready(sd, EXPECT_STATUS_GOOD) != 0);
+	while (testunitready(sd, EXPECT_STATUS_GOOD) != 0)
+		;
 
 
 	logging(LOG_VERBOSE, "Try to eject the medium");

--- a/utils/Makefile.am
+++ b/utils/Makefile.am
@@ -1,6 +1,6 @@
-AM_CPPFLAGS=-I../include "-D_U_=__attribute__((unused))" \
+AM_CPPFLAGS = -I../include "-D_U_=__attribute__((unused))" \
 	"-D_R_(A,B)=__attribute__((format(printf,A,B)))"
-AM_CFLAGS=$(WARN_CFLAGS) -lrt
+AM_CFLAGS = $(WARN_CFLAGS)
 LDADD = ../lib/libiscsi.la
 
 bin_PROGRAMS = iscsi-inq iscsi-ls iscsi-perf iscsi-readcapacity16 \

--- a/utils/iscsi-perf.c
+++ b/utils/iscsi-perf.c
@@ -76,12 +76,12 @@ void progress(struct client *client) {
 	uint64_t aiops = 1000000000UL * (client->iops) / (now - client->first_ns);
 	if (!_runtime) {
 		finished = 1;
-		printf ("iops average %lu (%lu MB/s)                                                        ", aiops, (aiops * blocks_per_io * client->blocksize) >> 20);
+		printf ("iops average %llu (%llu MB/s)                                                        ", aiops, (aiops * blocks_per_io * client->blocksize) >> 20);
 	} else {
 		uint64_t iops = 1000000000UL * (client->iops - client->last_iops) / (now - client->last_ns);
-		printf ("%02lu:%02lu:%02lu - ", (_runtime % 3600) / 60, _runtime / 60, _runtime % 60);
-		printf ("lba %lu, iops current %lu (%lu MB/s), ", client->pos, iops, (iops * blocks_per_io * client->blocksize) >> 20);
-		printf ("iops average %lu (%lu MB/s)         ", aiops, (aiops * blocks_per_io * client->blocksize) >> 20);
+		printf ("%02llu:%02llu:%02llu - ", (_runtime % 3600) / 60, _runtime / 60, _runtime % 60);
+		printf ("lba %llu, iops current %llu (%llu MB/s), ", client->pos, iops, (iops * blocks_per_io * client->blocksize) >> 20);
+		printf ("iops average %llu (%llu MB/s)         ", aiops, (aiops * blocks_per_io * client->blocksize) >> 20);
 	}
 	fflush(stdout);
 	client->last_ns = now;
@@ -274,14 +274,14 @@ int main(int argc, char *argv[])
 	
 	scsi_free_scsi_task(task);
 
-	printf("capacity is %lu blocks or %lu byte (%lu MB)\n", client.num_blocks, client.num_blocks * client.blocksize,
+	printf("capacity is %llu blocks or %llu byte (%llu MB)\n", client.num_blocks, client.num_blocks * client.blocksize,
 	                                                        (client.num_blocks * client.blocksize) >> 20);
 	                                                        
 	printf("performing %s READ with %d parallel requests\nfixed transfer size of %d blocks (%d byte)\n",
 	       client.random ? "random" : "sequential", max_in_flight, blocks_per_io, blocks_per_io * client.blocksize);
 
 	if (runtime) {
-		printf("will run for %lu seconds.\n", runtime);
+		printf("will run for %llu seconds.\n", runtime);
 	} else {
 		printf("infinite runtime - press CTRL-C to abort.\n");
 	}


### PR DESCRIPTION
When trying to compile libiscsi on OS X 10.9 I hit a few clang warnings and the new iscsi-perf makes use of clock_gettime which doesn't existing on OS X (see http://nadeausoftware.com/articles/2012/03/c_c_tip_how_measure_cpu_time_benchmarking#Discussion and http://stackoverflow.com/questions/5167269/clock-gettime-alternative-in-mac-os-x ). These patches fix these up (and tidy up some spacing in the util/Makefile.am while I'm there).

Looking at the fio source (https://github.com/axboe/fio/blob/1f440ece6127d2d274b961b6af0aa9091787702a/engines/posixaio.c#L36 ) shows that project uses gettimeofday when clock_gettime is unavailable so I do something similar here with autoconf (-lrt is always added to LIBS if we have clock_gettime) and ifdef headers. gettimeofday is bad because it's not necessarily monotonic and has usec accuracy at best but it's that or Mac OS X only ifdefs and code...