### PR TITLE
init: fix segfault in iscsi_destroy_context

### DIFF
--- a/lib/init.c
+++ b/lib/init.c
@@ -295,7 +295,7 @@ iscsi_destroy_context(struct iscsi_context *iscsi)
 			/* If an error happened during connect/login, we don't want to
 			   call any of the callbacks.
 			 */
-			if (iscsi->is_loggedin) {
+			if (iscsi->is_loggedin && pdu->callback != NULL) {
 				pdu->callback(iscsi, SCSI_STATUS_CANCELLED, NULL,
 						pdu->private_data);
 			}
@@ -307,7 +307,7 @@ iscsi_destroy_context(struct iscsi_context *iscsi)
 		/* If an error happened during connect/login, we don't want to
 		   call any of the callbacks.
 		 */
-		if (iscsi->is_loggedin) {
+		if (iscsi->is_loggedin && pdu->callback != NULL) {
 			pdu->callback(iscsi, SCSI_STATUS_CANCELLED, NULL,
 					pdu->private_data);
 		}


### PR DESCRIPTION
observed when iscsi_destroy_context is called while a iscsi NOP out is in flight.

Signed-off-by: Peter Lieven <pl@kamp.de>