### PR TITLE
Fix '0block' write same and unmap tests and 'out-of-tree' builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,8 @@ TAGS
 /test-tool/Makefile.in
 /test-tool/Makefile
 /test-tool/iscsi-test-cu
+/tests/Makefile.in
+/tests/Makefile
 /utils/Makefile.in
 /utils/Makefile
 /utils/iscsi-inq

--- a/examples/Makefile.am
+++ b/examples/Makefile.am
@@ -1,4 +1,4 @@
-AM_CPPFLAGS=-I. -I../include "-D_U_=__attribute__((unused))" \
+AM_CPPFLAGS=-I. -I${srcdir}/../include "-D_U_=__attribute__((unused))" \
 	"-D_R_(A,B)=__attribute__((format(printf,A,B)))"
 AM_CFLAGS=$(WARN_CFLAGS)
 LDADD = ../lib/libiscsi.la

--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -15,9 +15,9 @@ SOREVISON=0
 SOAGE=1
 libiscsi_la_LDFLAGS = \
 	-version-info $(SOCURRENT):$(SOREVISON):$(SOAGE) -bindir $(bindir) \
-	-no-undefined -export-symbols libiscsi.syms
+	-no-undefined -export-symbols ${srcdir}/libiscsi.syms
 
-libiscsi_la_CPPFLAGS = -I../include -I$(srcdir)/include \
+libiscsi_la_CPPFLAGS = -I${srcdir}/../include -I$(srcdir)/include \
 	"-D_U_=__attribute__((unused))" \
 	"-D_R_(A,B)=__attribute__((format(printf,A,B)))"
 

--- a/test-tool/Makefile.am
+++ b/test-tool/Makefile.am
@@ -1,4 +1,5 @@
-AM_CPPFLAGS=-I. -I../include "-D_U_=__attribute__((unused))" \
+AM_CPPFLAGS=-I. -I${srcdir}/../include \
+	"-D_U_=__attribute__((unused)) " \
 	"-D_R_(A,B)=__attribute__((format(printf,A,B)))"
 AM_CFLAGS=$(WARN_CFLAGS)
 LDADD = ../lib/libiscsi.la

--- a/test-tool/iscsi-support.c
+++ b/test-tool/iscsi-support.c
@@ -196,13 +196,14 @@ static int check_result(const char *opcode, struct scsi_device *sdev,
 	     || task->sense.key  != key
 	     || !ascq_ok)) {
 		logging(LOG_NORMAL, "[FAILED] %s failed with wrong sense. "
-			"Should have failed with %s(0x%02x)/%s(0x%04x)"
-			"but failed with Sense:%s\n",
+			"Should have failed with %s(0x%02x)/%s(0x%04x) "
+			"but failed with Sense: %s(0x%02x)/(0x%04x)\n",
 			opcode,
 			scsi_sense_key_str(key), key,
 			num_ascq ? scsi_sense_ascq_str(ascq[0]) : "NO ASCQ",
 			num_ascq ? ascq[0] : 0,
-			sdev->error_str);
+			sdev->error_str,
+			task->sense.key, task->sense.ascq);
 		return -1;
 	}
 	logging(LOG_VERBOSE, "[OK] %s returned %s %s(0x%02x) %s(0x%04x)",

--- a/test-tool/test_unmap_0blocks.c
+++ b/test-tool/test_unmap_0blocks.c
@@ -45,15 +45,6 @@ test_unmap_0blocks(void)
 		CU_ASSERT_EQUAL(ret, 0);
 	}
 
-	logging(LOG_VERBOSE, "Test UNMAP of 0 blocks at LBA:0-255  with one descriptor per block");
-	for (i = 0; i < 256; i++) {
-		list[i].lba = i;
-		list[i].num = 0;
-		ret = unmap(sd, 0, list, i,
-			    EXPECT_STATUS_GOOD);
-		CU_ASSERT_EQUAL(ret, 0);
-	}
-
 	logging(LOG_VERBOSE, "Test UNMAP of 0 blocks at end-of-LUN");
 	list[0].lba = num_blocks;
 	list[0].num = 0;
@@ -61,6 +52,25 @@ test_unmap_0blocks(void)
 		    EXPECT_STATUS_GOOD);
 	CU_ASSERT_EQUAL(ret, 0);
 
+	logging(LOG_VERBOSE, "Test UNMAP without any descriptors.");
+	ret = unmap(sd, 0, list, 0,
+		    EXPECT_STATUS_GOOD);
+	CU_ASSERT_EQUAL(ret, 0);
+
+
+	if (inq_bl->max_unmap_bdc <= 1) {
+		CU_PASS("[SKIPPING] Test UNMAP of 0 blocks with multiple descriptos not supported");
+		return;
+	}
+
+	logging(LOG_VERBOSE, "Test UNMAP of 0 blocks at LBA:0-255  with one descriptor per block");
+	for (i = 0; i < 256; i++) {
+		list[i].lba = i;
+		list[i].num = 0;
+		ret = unmap(sd, 0, list, i + 1,
+			    EXPECT_STATUS_GOOD);
+		CU_ASSERT_EQUAL(ret, 0);
+	}
 
 	logging(LOG_VERBOSE, "Test UNMAP of 0 blocks at LBA:0-255  with one descriptor per block, possibly \"overlapping\".");
 	for (i = 0; i < 256; i++) {
@@ -70,11 +80,4 @@ test_unmap_0blocks(void)
 	ret = unmap(sd, 0, list, 256,
 		    EXPECT_STATUS_GOOD);
 	CU_ASSERT_EQUAL(ret, 0);
-
-
-	logging(LOG_VERBOSE, "Test UNMAP without any descriptors.");
-	ret = unmap(sd, 0, list, 0,
-		    EXPECT_STATUS_GOOD);
-	CU_ASSERT_EQUAL(ret, 0);
-
 }

--- a/test-tool/test_writesame10_0blocks.c
+++ b/test-tool/test_writesame10_0blocks.c
@@ -41,6 +41,16 @@ test_writesame10_0blocks(void)
 	logging(LOG_VERBOSE, "Test WRITESAME10 0-blocks at LBA==0 (WSNZ=%d)",
 		inq_bl->wsnz);
 	memset(buf, 0, block_size);
+
+	if (inq_bl->wsnz) {
+		ret = writesame10(sd, 0,
+				  block_size, 0, 0, 0, 0, 0, buf,
+				  EXPECT_INVALID_FIELD_IN_CDB);
+		logging(LOG_NORMAL, "[SKIPPED] WRITESAME16 does not support 0-blocks.");
+		CU_ASSERT_EQUAL(ret, 0);
+		return;
+	}
+
 	ret = writesame10(sd, 0,
 			  block_size, 0, 0, 0, 0, 0, buf,
 			  EXPECT_STATUS_GOOD);
@@ -52,11 +62,7 @@ test_writesame10_0blocks(void)
 	} else if (ret == -4) {
 		CU_PASS("[SKIPPED] Number of WRITESAME10 logical blocks to be written exceeds MAXIMUM WRITE SAME LENGTH");
 	} else {
-		if (inq_bl->wsnz) {
-			CU_ASSERT_EQUAL(ret, -1);
-		} else {
-			CU_ASSERT_EQUAL(ret, 0);
-		}
+		CU_ASSERT_EQUAL(ret, 0);
 	}
 
 	logging(LOG_VERBOSE, "Test WRITESAME10 0-blocks one block past end-of-LUN");

--- a/test-tool/test_writesame10_unmap_until_end.c
+++ b/test-tool/test_writesame10_unmap_until_end.c
@@ -40,6 +40,12 @@ test_writesame10_unmap_until_end(void)
 	zeroBlock = alloca(block_size);
 	memset(zeroBlock, 0, block_size);
 
+	if (inq_bl->wsnz) {
+	    logging(LOG_NORMAL, "[SKIPPED] WRITESAME10 does not support 0-blocks.");
+	    CU_PASS("[SKIPPED] WRITESAME10 does not support 0-blocks.");
+	    return;
+	}
+
 	logging(LOG_VERBOSE, LOG_BLANK_LINE);
 	logging(LOG_VERBOSE, "Test WRITESAME10 of 1-256 blocks at the end of the LUN by setting number-of-blocks==0");
 	for (i = 1; i <= 256; i++) {
@@ -54,7 +60,7 @@ test_writesame10_unmap_until_end(void)
 
 		logging(LOG_VERBOSE, "Unmap %d blocks using WRITESAME10", i);
 		ret = writesame10(sd, num_blocks - i,
-				  block_size, i, 0, 1, 0, 0, buf,
+				  block_size, 0, 0, 1, 0, 0, buf,
 				  EXPECT_STATUS_GOOD);
 		CU_ASSERT_EQUAL(ret, 0);
 

--- a/test-tool/test_writesame16_0blocks.c
+++ b/test-tool/test_writesame16_0blocks.c
@@ -36,6 +36,16 @@ test_writesame16_0blocks(void)
 	logging(LOG_VERBOSE, "Test WRITESAME16 0-blocks at LBA==0 (WSNZ=%d)",
 		inq_bl->wsnz);
 	memset(buf, 0, block_size);
+
+	if (inq_bl->wsnz) {
+		ret = writesame16(sd, 0,
+				  block_size, 0, 0, 0, 0, 0, buf,
+				  EXPECT_INVALID_FIELD_IN_CDB);
+		logging(LOG_NORMAL, "[SKIPPED] WRITESAME16 does not support 0-blocks.");
+		CU_ASSERT_EQUAL(ret, 0);
+		return;
+	}
+
 	ret = writesame16(sd, 0,
 			  block_size, 0, 0, 0, 0, 0, buf,
 			  EXPECT_STATUS_GOOD);
@@ -48,30 +58,26 @@ test_writesame16_0blocks(void)
 	} else if (ret == -4) {
 		CU_PASS("[SKIPPED] Number of WRITESAME16 logical blocks to be written exceeds MAXIMUM WRITE SAME LENGTH");
 	} else {
-		if (inq_bl->wsnz) {
-			CU_ASSERT_EQUAL(ret, -1);
-		} else {
-			CU_ASSERT_EQUAL(ret, 0);
-		}
+		CU_ASSERT_EQUAL(ret, 0);
 	}
 
 	logging(LOG_VERBOSE, "Test WRITESAME16 0-blocks one block past end-of-LUN");
 	ret = writesame16(sd, num_blocks + 1,
-			  block_size, inq_bl->wsnz, 0, 0, 0, 0, buf,
+			  block_size, 0, 0, 0, 0, 0, buf,
 			  EXPECT_LBA_OOB);
 	CU_ASSERT_EQUAL(ret, 0);
 
 
 	logging(LOG_VERBOSE, "Test WRITESAME16 0-blocks at LBA==2^63");
 	ret = writesame16(sd, 0x8000000000000000ULL,
-			  block_size, inq_bl->wsnz, 0, 0, 0, 0, buf,
+			  block_size, 0, 0, 0, 0, 0, buf,
 			  EXPECT_LBA_OOB);
 	CU_ASSERT_EQUAL(ret, 0);
 
 
 	logging(LOG_VERBOSE, "Test WRITESAME16 0-blocks at LBA==-1");
 	ret = writesame16(sd, -1,
-			  block_size, inq_bl->wsnz, 0, 0, 0, 0, buf,
+			  block_size, 0, 0, 0, 0, 0, buf,
 			  EXPECT_LBA_OOB);
 	CU_ASSERT_EQUAL(ret, 0);
 }

--- a/test-tool/test_writesame16_unmap_until_end.c
+++ b/test-tool/test_writesame16_unmap_until_end.c
@@ -39,6 +39,12 @@ test_writesame16_unmap_until_end(void)
 	CHECK_FOR_LBPWS;
 	CHECK_FOR_SBC;
 
+	if (inq_bl->wsnz) {
+	    logging(LOG_NORMAL, "[SKIPPED] WRITESAME10 does not support 0-blocks.");
+	    CU_PASS("[SKIPPED] WRITESAME10 does not support 0-blocks.");
+	    return;
+	}
+
 	zeroBlock = alloca(block_size);
 	memset(zeroBlock, 0, block_size);
 

--- a/test-tool/test_writesame16_unmap_until_end.c
+++ b/test-tool/test_writesame16_unmap_until_end.c
@@ -58,8 +58,9 @@ test_writesame16_unmap_until_end(void)
 			      i * block_size, block_size, 0, 0, 0, 0, 0, buf,
 			      EXPECT_STATUS_GOOD);
 		logging(LOG_VERBOSE, "Unmap %d blocks using WRITESAME16", i);
+		memset(buf, 0, block_size);
 		ret = writesame16(sd, num_blocks - i,
-				  0, i, 0, 1, 0, 0, NULL,
+				  block_size, 0, 0, 1, 0, 0, buf,
 				  EXPECT_STATUS_GOOD);
 		if (ret == -2) {
 			logging(LOG_NORMAL, "[SKIPPED] WRITESAME16 is not implemented.");

--- a/utils/Makefile.am
+++ b/utils/Makefile.am
@@ -1,4 +1,4 @@
-AM_CPPFLAGS = -I../include "-D_U_=__attribute__((unused))" \
+AM_CPPFLAGS = -I${srcdir}/../include "-D_U_=__attribute__((unused))" \
 	"-D_R_(A,B)=__attribute__((format(printf,A,B)))"
 AM_CFLAGS = $(WARN_CFLAGS)
 LDADD = ../lib/libiscsi.la


### PR DESCRIPTION
This patchset fixes writesame and unmap tests for targets that have WSNZ bit enabled by skipping the affected tests (printing a proper message) including a couple of other fixes where the number of blocks passed to writesame and unmap was incorrect. It also fixes 'out-of-tree' builds and adds two generated files to .gitignore.