### PR TITLE
test: multipath support v2

### DIFF
--- a/test-tool/Makefile.am
+++ b/test-tool/Makefile.am
@@ -8,6 +8,7 @@ EXTRA_DIST = README
 
 dist_noinst_HEADERS = iscsi-support.h \
 		      iscsi-test-cu.h
+		      iscsi-multipath.h
 
 # libiscsi test tool using cunit
 if ISCSITEST
@@ -15,6 +16,7 @@ bin_PROGRAMS = iscsi-test-cu
 iscsi_test_cu_LDFLAGS = -ldl -lcunit
 iscsi_test_cu_SOURCES = iscsi-test-cu.c \
 	iscsi-support.c \
+	iscsi-multipath.c \
 	test_compareandwrite_simple.c \
 	test_compareandwrite_dpofua.c \
 	test_compareandwrite_miscompare.c \

--- a/test-tool/Makefile.am
+++ b/test-tool/Makefile.am
@@ -201,7 +201,8 @@ iscsi_test_cu_SOURCES = iscsi-test-cu.c \
 	test_writeverify16_wrprotect.c \
 	test_writeverify16_flags.c \
 	test_writeverify16_dpo.c \
-	test_writeverify16_residuals.c
+	test_writeverify16_residuals.c \
+	test_multipathio_simple.c
 
 endif
 

--- a/test-tool/iscsi-multipath.c
+++ b/test-tool/iscsi-multipath.c
@@ -1,0 +1,366 @@
+/*
+   iscsi test-tool multipath support
+
+   Copyright (C) 2015 David Disseldorp
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; either version 2 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program; if not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "config.h"
+
+#define _GNU_SOURCE
+#include <assert.h>
+#include <sys/syscall.h>
+#include <dlfcn.h>
+#include <sys/types.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include <stdarg.h>
+#include <inttypes.h>
+#include <string.h>
+#include <poll.h>
+#include <fnmatch.h>
+
+#ifdef HAVE_SG_IO
+#include <fcntl.h>
+#include <sys/ioctl.h>
+#include <scsi/sg.h>
+#endif
+
+#include "slist.h"
+#include "iscsi.h"
+#include "scsi-lowlevel.h"
+#include "iscsi-private.h"
+#include "iscsi-support.h"
+#include "iscsi-multipath.h"
+
+int mp_num_sds = 0;
+struct scsi_device *mp_sds[MPATH_MAX_DEVS];
+
+static void
+mpath_des_free(struct scsi_inquiry_device_designator *des)
+{
+	if (!des) {
+		return;
+	}
+
+	free(des->designator);
+	free(des);
+}
+
+static int
+mpath_des_copy(struct scsi_inquiry_device_designator *des,
+	       struct scsi_inquiry_device_designator **_des_cp)
+{
+	struct scsi_inquiry_device_designator *des_cp;
+
+	if (!_des_cp) {
+		return -1;
+	}
+
+	des_cp = malloc(sizeof(*des_cp));
+	if (des_cp == NULL) {
+		return -1;
+	}
+
+	des_cp->protocol_identifier = des->protocol_identifier;
+	des_cp->code_set = des->code_set;
+	des_cp->piv = des->piv;
+	des_cp->association = des->association;
+	des_cp->designator_type = des->designator_type;
+	des_cp->designator_length = des->designator_length;
+	des_cp->designator = malloc(des->designator_length);
+	if (des_cp->designator == NULL) {
+		free(des_cp);
+		return -1;
+	}
+	memcpy(des_cp->designator, des->designator, des->designator_length);
+	*_des_cp = des;
+
+	return 0;
+}
+
+static int
+mpath_des_cmp(struct scsi_inquiry_device_designator *des1,
+	      struct scsi_inquiry_device_designator *des2)
+{
+	if (des1->protocol_identifier != des2->protocol_identifier) {
+		return -1;
+	}
+
+	if (des1->code_set != des2->code_set) {
+		return -1;
+	}
+
+	if (des1->piv != des2->piv) {
+		return -1;
+	}
+
+	if (des1->association != des2->association) {
+		return -1;
+	}
+
+	if (des1->designator_type != des2->designator_type) {
+		return -1;
+	}
+
+	if (des1->designator_length != des2->designator_length) {
+		return -1;
+	}
+
+	return memcmp(des1->designator, des2->designator,
+		      des1->designator_length);
+}
+
+static int
+mpath_check_matching_ids_devid_vpd(int num_sds,
+				   struct scsi_device **sds)
+{
+	int i;
+	int num_sds_with_valid_id = 0;
+	struct scsi_task *inq_task = NULL;
+	struct scsi_inquiry_device_designator *des_saved = NULL;
+
+	for (i = 0; i < num_sds; i++) {
+		int ret;
+		int full_size;
+		struct scsi_inquiry_device_identification *inq_id_data;
+		struct scsi_inquiry_device_designator *des;
+
+		/*
+		 * dev ID inquiry to confirm that all multipath devices carry
+		 * an identical logical unit identifier.
+		 */
+		inquiry(sds[i], &inq_task, 1,
+			SCSI_INQUIRY_PAGECODE_DEVICE_IDENTIFICATION, 64,
+			EXPECT_STATUS_GOOD);
+		if (inq_task && inq_task->status != SCSI_STATUS_GOOD) {
+			printf("Inquiry command failed : %s\n",
+			       sds[i]->error_str);
+			goto err_cleanup;
+		}
+		full_size = scsi_datain_getfullsize(inq_task);
+		if (full_size > inq_task->datain.size) {
+			/* we need more data */
+			scsi_free_scsi_task(inq_task);
+			inq_task = NULL;
+			inquiry(sds[i], &inq_task, 0, 0, full_size,
+				EXPECT_STATUS_GOOD);
+			if (inq_task == NULL) {
+				printf("Inquiry command failed : %s\n",
+				       sds[i]->error_str);
+				goto err_cleanup;
+			}
+		}
+
+		inq_id_data = scsi_datain_unmarshall(inq_task);
+		if (inq_id_data == NULL) {
+			printf("failed to unmarshall inquiry ID datain blob\n");
+			goto err_cleanup;
+		}
+
+		if (inq_id_data->qualifier
+			       != SCSI_INQUIRY_PERIPHERAL_QUALIFIER_CONNECTED) {
+			printf("error: multipath device not connected\n");
+			goto err_cleanup;
+		}
+
+		if (inq_id_data->device_type
+			 != SCSI_INQUIRY_PERIPHERAL_DEVICE_TYPE_DIRECT_ACCESS) {
+			printf("error: multipath devices must be SBC\n");
+			goto err_cleanup;
+		}
+
+		/* walk the list of IDs, and find a suitable LU candidate */
+		for (des = inq_id_data->designators;
+		     des != NULL;
+		     des = des->next) {
+			if (des->association != SCSI_ASSOCIATION_LOGICAL_UNIT) {
+				printf("skipping non-LU designator: %d\n",
+				       des->association);
+				continue;
+			}
+
+			if ((des->designator_type != SCSI_DESIGNATOR_TYPE_EUI_64)
+			 && (des->designator_type != SCSI_DESIGNATOR_TYPE_NAA)
+			 && (des->designator_type != SCSI_DESIGNATOR_TYPE_MD5_LOGICAL_UNIT_IDENTIFIER)
+			 && (des->designator_type != SCSI_DESIGNATOR_TYPE_SCSI_NAME_STRING)) {
+				printf("skipping unsupported des type: %d\n",
+				       des->designator_type);
+				continue;
+			}
+
+			if (des->designator_length <= 0) {
+				printf("skipping designator with bad len: %d\n",
+				       des->designator_length);
+				continue;
+			}
+
+			if (des_saved == NULL) {
+				ret = mpath_des_copy(des, &des_saved);
+				if (ret < 0) {
+					goto err_cleanup;
+				}
+				/*
+				 * we now have a reference to look for in all
+				 * subsequent paths.
+				 */
+				num_sds_with_valid_id++;
+				break;
+			} else if (mpath_des_cmp(des, des_saved) == 0) {
+				/* found match for previous path designator */
+				num_sds_with_valid_id++;
+				break;
+			}
+			/* no match yet, keep checking other designators */
+		}
+
+		scsi_free_scsi_task(inq_task);
+		inq_task = NULL;
+	}
+	mpath_des_free(des_saved);
+
+	if (num_sds_with_valid_id != num_sds) {
+		printf("failed to find matching LU device ID for all paths\n");
+		return -1;
+	}
+
+	printf("found matching LU device identifier for all (%d) paths\n",
+	       num_sds);
+	return 0;
+
+err_cleanup:
+	mpath_des_free(des_saved);
+	scsi_free_scsi_task(inq_task);
+	return -1;
+}
+
+static int
+mpath_check_matching_ids_serial_vpd(int num_sds,
+				    struct scsi_device **sds)
+{
+	int i;
+	int num_sds_with_valid_id = 0;
+	struct scsi_task *inq_task = NULL;
+	char *usn_saved = NULL;
+
+	for (i = 0; i < num_sds; i++) {
+		int full_size;
+		struct scsi_inquiry_unit_serial_number *inq_serial;
+
+		/*
+		 * inquiry to confirm that all multipath devices carry an
+		 * identical unit serial number.
+		 */
+		inq_task = NULL;
+		inquiry(sds[i], &inq_task, 1,
+			SCSI_INQUIRY_PAGECODE_UNIT_SERIAL_NUMBER, 64,
+			EXPECT_STATUS_GOOD);
+		if (inq_task && inq_task->status != SCSI_STATUS_GOOD) {
+			printf("Inquiry command failed : %s\n",
+			       sds[i]->error_str);
+			goto err_cleanup;
+		}
+		full_size = scsi_datain_getfullsize(inq_task);
+		if (full_size > inq_task->datain.size) {
+			scsi_free_scsi_task(inq_task);
+
+			/* we need more data */
+			inq_task = NULL;
+			inquiry(sds[i], &inq_task, 0, 0, full_size,
+				EXPECT_STATUS_GOOD);
+			if (inq_task == NULL) {
+				printf("Inquiry command failed : %s\n",
+				       sds[i]->error_str);
+				goto err_cleanup;
+			}
+		}
+
+		inq_serial = scsi_datain_unmarshall(inq_task);
+		if (inq_serial == NULL) {
+			printf("failed to unmarshall inquiry datain blob\n");
+			goto err_cleanup;
+		}
+
+		if (inq_serial->qualifier
+			       != SCSI_INQUIRY_PERIPHERAL_QUALIFIER_CONNECTED) {
+			printf("error: multipath device not connected\n");
+			goto err_cleanup;
+		}
+
+		if (inq_serial->device_type
+			 != SCSI_INQUIRY_PERIPHERAL_DEVICE_TYPE_DIRECT_ACCESS) {
+			printf("error: multipath devices must be SBC\n");
+			goto err_cleanup;
+		}
+
+		if (inq_serial->usn == NULL) {
+			printf("error: empty usn for multipath device\n");
+			goto err_cleanup;
+		}
+
+		if (usn_saved == NULL) {
+			usn_saved = strdup(inq_serial->usn);
+			if (usn_saved == NULL) {
+				goto err_cleanup;
+			}
+			num_sds_with_valid_id++;
+		} else if (strcmp(usn_saved, inq_serial->usn) == 0) {
+			num_sds_with_valid_id++;
+		} else {
+			printf("multipath unit serial mismatch: %s != %s\n",
+			       usn_saved, inq_serial->usn);
+		}
+
+		scsi_free_scsi_task(inq_task);
+		inq_task = NULL;
+	}
+
+	if (num_sds_with_valid_id != num_sds) {
+		printf("failed to find matching serial number for all paths\n");
+		goto err_cleanup;
+	}
+
+	printf("found matching serial number for all (%d) paths: %s\n",
+	       num_sds, usn_saved);
+	free(usn_saved);
+
+	return 0;
+
+err_cleanup:
+	free(usn_saved);
+	scsi_free_scsi_task(inq_task);
+	return -1;
+}
+
+int
+mpath_check_matching_ids(int num_sds,
+			 struct scsi_device **sds)
+{
+	int ret;
+
+	/*
+	 * first check all devices for a matching LU identifier in the device
+	 * identification INQUIRY VPD page.
+	 */
+	ret = mpath_check_matching_ids_devid_vpd(num_sds, sds);
+	if (ret == 0) {
+		return 0;	/* found matching */
+	}
+
+	/* fall back to a unit serial number check */
+	ret = mpath_check_matching_ids_serial_vpd(num_sds, sds);
+	return ret;
+}

--- a/test-tool/iscsi-multipath.h
+++ b/test-tool/iscsi-multipath.h
@@ -24,6 +24,17 @@
 extern int mp_num_sds;
 extern struct scsi_device *mp_sds[MPATH_MAX_DEVS];
 
+#define MPATH_SKIP_IF_UNAVAILABLE(_sds, _num_sds)			\
+do {									\
+	if (_num_sds <= 1) {						\
+		logging(LOG_NORMAL, "[SKIPPED] Multipath unavailable."	\
+			" Skipping test");				\
+		CU_PASS("[SKIPPED] Multipath unavailable."		\
+			" Skipping test");				\
+		return;							\
+	}								\
+} while (0);
+
 int
 mpath_check_matching_ids(int num_sds,
 			 struct scsi_device **sds);

--- a/test-tool/iscsi-multipath.h
+++ b/test-tool/iscsi-multipath.h
@@ -1,0 +1,31 @@
+/*
+   iscsi test-tool multipath support
+
+   Copyright (C) 2015 David Disseldorp
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; either version 2 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program; if not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef	_ISCSI_MULTIPATH_H_
+#define	_ISCSI_MULTIPATH_H_
+
+#define MPATH_MAX_DEVS 2
+extern int mp_num_sds;
+extern struct scsi_device *mp_sds[MPATH_MAX_DEVS];
+
+int
+mpath_check_matching_ids(int num_sds,
+			 struct scsi_device **sds);
+
+#endif	/* _ISCSI_MULTIPATH_H_ */

--- a/test-tool/iscsi-test-cu.c
+++ b/test-tool/iscsi-test-cu.c
@@ -417,6 +417,11 @@ static CU_TestInfo tests_writeverify16[] = {
 	CU_TEST_INFO_NULL
 };
 
+static CU_TestInfo tests_multipathio[] = {
+	{ (char *)"Simple", test_multipathio_simple },
+	CU_TEST_INFO_NULL
+};
+
 typedef struct libiscsi_suite_info {
         const char       *pName;         /**< Suite name. */
         CU_InitializeFunc pInitFunc;     /**< Suite initialization function. */
@@ -469,6 +474,7 @@ static libiscsi_suite_info scsi_suites[] = {
 	{ "WriteVerify10", NON_PGR_FUNCS, tests_writeverify10 },
 	{ "WriteVerify12", NON_PGR_FUNCS, tests_writeverify12 },
 	{ "WriteVerify16", NON_PGR_FUNCS, tests_writeverify16 },
+	{ "MultipathIO", NON_PGR_FUNCS, tests_multipathio },
 	{ NULL, NULL, NULL, NULL, NULL, NULL }
 };
 
@@ -553,6 +559,7 @@ static libiscsi_suite_info all_suites[] = {
 	{ "iSCSIcmdsn", NON_PGR_FUNCS, tests_iscsi_cmdsn },
 	{ "iSCSIdatasn", NON_PGR_FUNCS, tests_iscsi_datasn },
 	{ "iSCSIResiduals", NON_PGR_FUNCS, tests_iscsi_residuals },
+	{ "MultipathIO", NON_PGR_FUNCS, tests_multipathio },
 	{ NULL, NULL, NULL, NULL, NULL, NULL },
 };
 
@@ -586,6 +593,7 @@ static libiscsi_suite_info linux_suites[] = {
 	{ "WriteVerify10", NON_PGR_FUNCS, tests_writeverify10 },
 	{ "WriteVerify12", NON_PGR_FUNCS, tests_writeverify12 },
 	{ "WriteVerify16", NON_PGR_FUNCS, tests_writeverify16 },
+	{ "MultipathIO", NON_PGR_FUNCS, tests_multipathio },
 	{ NULL, NULL, NULL, NULL, NULL, NULL },
 };
 

--- a/test-tool/iscsi-test-cu.c
+++ b/test-tool/iscsi-test-cu.c
@@ -26,6 +26,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <stdint.h>
+#include <stdbool.h>
 #include <unistd.h>
 #include <string.h>
 #include <getopt.h>
@@ -50,11 +51,12 @@
 #include "iscsi-support.h"
 #include "iscsi-test-cu.h"
 #include "iscsi-support.h"
+#include "iscsi-multipath.h"
 
 #define	PROG	"iscsi-test-cu"
 
 int loglevel = LOG_NORMAL;
-struct scsi_device *sd;
+struct scsi_device *sd = NULL;	/* mp_sds[0] alias */
 static unsigned int maxsectbytes;
 
 /*
@@ -613,7 +615,7 @@ print_usage(void)
 	    "Usage: %s [-?|--help]    print this message and exit\n",
 	    PROG);
 	fprintf(stderr,
-	    "or     %s [OPTIONS] <iscsi-url>\n", PROG);
+	    "or     %s [OPTIONS] <iscsi-url> [multipath-iscsi-url]\n", PROG);
 	fprintf(stderr,
 	    "Where OPTIONS are from:\n");
 	fprintf(stderr,
@@ -683,13 +685,20 @@ test_teardown(void)
 int
 suite_init(void)
 {
-	if (sd->iscsi_url) {
-		if (sd->iscsi_ctx) {
-			iscsi_logout_sync(sd->iscsi_ctx);
-			iscsi_destroy_context(sd->iscsi_ctx);
+	int i;
+
+	for (i = 0; i < mp_num_sds; i++) {
+		if (!mp_sds[i]->iscsi_url) {
+			continue;
 		}
-		sd->iscsi_ctx = iscsi_context_login(initiatorname1, sd->iscsi_url, &sd->iscsi_lun);
-		if (sd->iscsi_ctx == NULL) {
+		if (mp_sds[i]->iscsi_ctx) {
+			iscsi_logout_sync(mp_sds[i]->iscsi_ctx);
+			iscsi_destroy_context(mp_sds[i]->iscsi_ctx);
+		}
+		mp_sds[i]->iscsi_ctx = iscsi_context_login(initiatorname1,
+							mp_sds[i]->iscsi_url,
+							&mp_sds[i]->iscsi_lun);
+		if (mp_sds[i]->iscsi_ctx == NULL) {
 			fprintf(stderr,
 				"error: Failed to login to target for test set-up\n");
 			return 1;
@@ -705,15 +714,19 @@ suite_init(void)
 int
 suite_cleanup(void)
 {
+	int i;
+
 #ifndef HAVE_CU_SUITEINFO_PSETUPFUNC
 	/* libcunit version 1 */
 	test_teardown();
 #endif
-	if (sd->iscsi_url) {
-		if (sd->iscsi_ctx) {
-			iscsi_logout_sync(sd->iscsi_ctx);
-			iscsi_destroy_context(sd->iscsi_ctx);
-			sd->iscsi_ctx = NULL;
+	for (i = 0; i < mp_num_sds; i++) {
+		if (mp_sds[i]->iscsi_url) {
+			if (mp_sds[i]->iscsi_ctx) {
+				iscsi_logout_sync(mp_sds[i]->iscsi_ctx);
+				iscsi_destroy_context(mp_sds[i]->iscsi_ctx);
+				mp_sds[i]->iscsi_ctx = NULL;
+			}
 		}
 	}
 	return 0;
@@ -933,7 +946,7 @@ static void free_scsi_device(struct scsi_device *sdev)
 		close(sdev->sgio_fd);
 		sdev->sgio_fd = -1;
 	}
-	free(sd);
+	free(sdev);
 }
 
 int
@@ -972,10 +985,7 @@ main(int argc, char *argv[])
 	};
 	int i, c;
 	int opt_idx = 0;
-
-	sd = malloc(sizeof(struct scsi_device));
-	memset(sd, '\0', sizeof(struct scsi_device));
-	sd->sgio_fd = -1;
+	bool got_sgio_dev = false;
 
 	while ((c = getopt_long(argc, argv, "?hli:I:t:sdgfAsSnvxV", long_opts,
 		    &opt_idx)) > 0) {
@@ -1034,29 +1044,40 @@ main(int argc, char *argv[])
 		}
 	}
 
-	if (optind < argc) {
+	/* parse all trailing arguments as device paths */
+	mp_num_sds = 0;
+	while (optind < argc) {
+		if (mp_num_sds >= MPATH_MAX_DEVS) {
+			fprintf(stderr, "Too many multipath device URLs\n");
+			print_usage();
+			free(testname_re);
+			return 10;
+		}
+
+		mp_sds[mp_num_sds] = malloc(sizeof(struct scsi_device));
+		memset(mp_sds[mp_num_sds], '\0', sizeof(struct scsi_device));
+		mp_sds[mp_num_sds]->sgio_fd = -1;
+
 		if (!strncmp(argv[optind], "iscsi://", 8)) {
-			sd->iscsi_url = strdup(argv[optind++]);
+			mp_sds[mp_num_sds]->iscsi_url = strdup(argv[optind++]);
 #ifdef HAVE_SG_IO
 		} else {
-			sd->sgio_dev = strdup(argv[optind++]);
+			mp_sds[mp_num_sds]->sgio_dev = strdup(argv[optind++]);
+			got_sgio_dev = true;
 #endif
 		}
-	}
-	if (optind < argc) {
-		fprintf(stderr, "error: too many arguments\n");
-		print_usage();
-		return 1;
+		mp_num_sds++;
 	}
 
 	/* XXX why is this done? */
 	real_iscsi_queue_pdu = dlsym(RTLD_NEXT, "iscsi_queue_pdu");
 
-	if (sd->iscsi_url == NULL && sd->sgio_dev== NULL ) {
+	if ((mp_num_sds == 0) || (mp_sds[0]->iscsi_url == NULL
+					&& mp_sds[0]->sgio_dev == NULL)) {
 #ifdef HAVE_SG_IO
 		fprintf(stderr, "You must specify either an iSCSI URL or a device file\n");
 #else
-		fprintf(stderr, "You must specify either an iSCSI URL\n");
+		fprintf(stderr, "You must specify an iSCSI URL\n");
 #endif
 		print_usage();
 		if (testname_re)
@@ -1064,10 +1085,32 @@ main(int argc, char *argv[])
 		return 10;
 	}
 
-	if (connect_scsi_device(sd, initiatorname1)) {
-		fprintf(stderr, "Failed to connect to SCSI device\n");
-		free_scsi_device(sd);
-		return -1;
+	if ((mp_num_sds > 1) && got_sgio_dev) {
+		fprintf(stderr, "Multipath devices must be iSCSI only\n");
+		print_usage();
+		free(testname_re);
+		return 10;
+	}
+
+	/* sd remains an alias for the first device */
+	sd = mp_sds[0];
+
+	for (i = 0; i < mp_num_sds; i++) {
+		res = connect_scsi_device(mp_sds[i], initiatorname1);
+		if (res < 0) {
+			fprintf(stderr,
+				"Failed to connect to SCSI device %d\n", i);
+			goto err_sds_free;
+		}
+	}
+
+	if (mp_num_sds > 1) {
+		/* check that all multipath sds identify as the same LU */
+		res = mpath_check_matching_ids(mp_num_sds, mp_sds);
+		if (res < 0) {
+			fprintf(stderr, "multipath devices don't match\n");
+			goto err_sds_free;
+		}
 	}
 
 	/*
@@ -1079,21 +1122,18 @@ main(int argc, char *argv[])
 	readcapacity10(sd, &task, 0, 0, EXPECT_STATUS_GOOD);
 	if (task == NULL) {
 		printf("Failed to send READCAPACITY10 command: %s\n", sd->error_str);
-		free_scsi_device(sd);
-		return -1;
+		goto err_sds_free;
 	}
 	if (task->status != SCSI_STATUS_GOOD) {
 		printf("READCAPACITY10 command: failed with sense. %s\n", sd->error_str);
 		scsi_free_scsi_task(task);
-		free_scsi_device(sd);
-		return -1;
+		goto err_sds_free;
 	}
 	rc10 = scsi_datain_unmarshall(task);
 	if (rc10 == NULL) {
 		printf("failed to unmarshall READCAPACITY10 data.\n");
 		scsi_free_scsi_task(task);
-		free_scsi_device(sd);
-		return -1;
+		goto err_sds_free;
 	}
 	block_size = rc10->block_size;
 	num_blocks = rc10->lba + 1;
@@ -1103,16 +1143,14 @@ main(int argc, char *argv[])
 	readcapacity16(sd, &rc16_task, 96, EXPECT_STATUS_GOOD);
 	if (rc16_task == NULL) {
 		printf("Failed to send READCAPACITY16 command: %s\n", sd->error_str);
-		free_scsi_device(sd);
-		return -1;
+		goto err_sds_free;
 	}
 	if (rc16_task->status == SCSI_STATUS_GOOD) {
 		rc16 = scsi_datain_unmarshall(rc16_task);
 		if (rc16 == NULL) {
 			printf("failed to unmarshall READCAPACITY16 data. %s\n", sd->error_str);
 			scsi_free_scsi_task(rc16_task);
-			free_scsi_device(sd);
-			return -1;
+			goto err_sds_free;
 		}
 		block_size = rc16->block_length;
 		num_blocks = rc16->returned_lba + 1;
@@ -1123,7 +1161,7 @@ main(int argc, char *argv[])
 	inquiry(sd, &inq_task, 0, 0, 64, EXPECT_STATUS_GOOD);
 	if (inq_task == NULL || inq_task->status != SCSI_STATUS_GOOD) {
 		printf("Inquiry command failed : %s\n", sd->error_str);
-		return -1;
+		goto err_sds_free;
 	}
 	full_size = scsi_datain_getfullsize(inq_task);
 	if (full_size > inq_task->datain.size) {
@@ -1134,14 +1172,14 @@ main(int argc, char *argv[])
 		inquiry(sd, &inq_task, 0, 0, full_size, EXPECT_STATUS_GOOD);
 		if (inq_task == NULL) {
 			printf("Inquiry command failed : %s\n", sd->error_str);
-			return -1;
+			goto err_sds_free;
 		}
 	}
 	inq = scsi_datain_unmarshall(inq_task);
 	if (inq == NULL) {
 		printf("failed to unmarshall inquiry datain blob\n");
 		scsi_free_scsi_task(inq_task);
-		return -1;
+		goto err_sds_free;
 	}
 
 	sbc3_support = 0;
@@ -1168,14 +1206,14 @@ main(int argc, char *argv[])
 				EXPECT_STATUS_GOOD);
 			if (inq_bl_task == NULL) {
 				printf("Inquiry command failed : %s\n", sd->error_str);
-				return -1;
+				goto err_sds_free;
 			}
 		}
 
 		inq_bl = scsi_datain_unmarshall(inq_bl_task);
 		if (inq_bl == NULL) {
 			printf("failed to unmarshall inquiry datain blob\n");
-			return -1;
+			goto err_sds_free;
 		}
 	}
 
@@ -1188,7 +1226,7 @@ main(int argc, char *argv[])
 		inq_bdc = scsi_datain_unmarshall(inq_bdc_task);
 		if (inq_bdc == NULL) {
 			printf("failed to unmarshall inquiry datain blob\n");
-			return -1;
+			goto err_sds_free;
 		}
 	}
 
@@ -1199,7 +1237,7 @@ main(int argc, char *argv[])
 			EXPECT_STATUS_GOOD);
 		if (inq_lbp_task == NULL || inq_lbp_task->status != SCSI_STATUS_GOOD) {
 			printf("Inquiry command failed : %s\n", sd->error_str);
-			return -1;
+			goto err_sds_free;
 		}
 		full_size = scsi_datain_getfullsize(inq_lbp_task);
 		if (full_size > inq_lbp_task->datain.size) {
@@ -1211,14 +1249,14 @@ main(int argc, char *argv[])
 				full_size, EXPECT_STATUS_GOOD);
 			if (inq_lbp_task == NULL) {
 				printf("Inquiry command failed : %s\n", sd->error_str);
-				return -1;
+				goto err_sds_free;
 			}
 		}
 
 		inq_lbp = scsi_datain_unmarshall(inq_lbp_task);
 		if (inq_lbp == NULL) {
 			printf("failed to unmarshall inquiry datain blob\n");
-			return -1;
+			goto err_sds_free;
 		}
 	}
 
@@ -1227,8 +1265,7 @@ main(int argc, char *argv[])
 				 EXPECT_STATUS_GOOD);
 	if (rsop_task == NULL) {
 		printf("Failed to send REPORT_SUPPORTED_OPCODES command: %s\n", sd->error_str);
-		free_scsi_device(sd);
-		return -1;
+		goto err_sds_free;
 	}
 	if (rsop_task->status == SCSI_STATUS_GOOD) {
 		rsop = scsi_datain_unmarshall(rsop_task);
@@ -1244,8 +1281,7 @@ main(int argc, char *argv[])
 		   EXPECT_STATUS_GOOD);
 	if (task == NULL) {
 		printf("Failed to send MODE_SENSE6 command: %s\n", sd->error_str);
-		free_scsi_device(sd);
-		return -1;
+		goto err_sds_free;
 	}
 	if (task->status == SCSI_STATUS_GOOD) {
 		struct scsi_mode_sense *ms;
@@ -1254,7 +1290,7 @@ main(int argc, char *argv[])
 		if (ms == NULL) {
 			printf("failed to unmarshall mode sense datain blob\n");
 			scsi_free_scsi_task(task);
-			return -1;
+			goto err_sds_free;
 		}
 		readonly = !!(ms->device_specific_parameter & 0x80);
 	}
@@ -1268,7 +1304,7 @@ main(int argc, char *argv[])
 
 	if (CU_initialize_registry() != 0) {
 		fprintf(stderr, "error: unable to initialize test registry\n");
-		return 1;
+		goto err_sds_free;
 	}
 	if (CU_is_test_running()) {
 		fprintf(stderr, "error: test suite(s) already running!?\n");
@@ -1315,7 +1351,15 @@ main(int argc, char *argv[])
 	if (rsop_task != NULL) {
 		scsi_free_scsi_task(rsop_task);
 	}
-	free_scsi_device(sd);
+	for (i = 0; i < mp_num_sds; i++) {
+		free_scsi_device(mp_sds[i]);
+	}
 
 	return 0;
+
+err_sds_free:
+	for (i = 0; i < mp_num_sds; i++) {
+		free_scsi_device(mp_sds[i]);
+	}
+	return -1;
 }

--- a/test-tool/iscsi-test-cu.h
+++ b/test-tool/iscsi-test-cu.h
@@ -283,4 +283,6 @@ void test_writeverify16_flags(void);
 void test_writeverify16_dpo(void);
 void test_writeverify16_residuals(void);
 
+void test_multipathio_simple(void);
+
 #endif	/* _ISCSI_TEST_CU_H_ */

--- a/test-tool/test_multipathio_simple.c
+++ b/test-tool/test_multipathio_simple.c
@@ -1,0 +1,82 @@
+/*
+   Copyright (C) 2013 Ronnie Sahlberg <ronniesahlberg@gmail.com>
+   Copyright (C) 2015 David Disseldorp
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; either version 2 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program; if not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <stdio.h>
+#include <stdlib.h>
+
+#include <CUnit/CUnit.h>
+
+#include "iscsi.h"
+#include "scsi-lowlevel.h"
+#include "iscsi-support.h"
+#include "iscsi-test-cu.h"
+#include "iscsi-multipath.h"
+
+void
+test_multipathio_simple(void)
+{
+	int write_path;
+	unsigned char *write_buf = alloca(256 * block_size);
+	unsigned char *read_buf = alloca(256 * block_size);
+
+	CHECK_FOR_DATALOSS;
+	CHECK_FOR_SBC;
+	MPATH_SKIP_IF_UNAVAILABLE(mp_sds, mp_num_sds);
+
+	logging(LOG_VERBOSE, LOG_BLANK_LINE);
+	memset(write_buf, 0xa6, 256 * block_size);
+
+	for (write_path = 0; write_path < mp_num_sds; write_path++) {
+		int i, ret;
+		int read_path;
+
+		/* read back written data using a different path */
+		read_path = (write_path + 1) % mp_num_sds;
+
+		logging(LOG_VERBOSE,
+			"Test multipath WRITE16/READ16 of 1-256 blocks using "
+			"path %d", write_path);
+
+		for (i = 1; i <= 256; i++) {
+			if (maximum_transfer_length
+					&& maximum_transfer_length < i) {
+				break;
+			}
+			ret = write16(mp_sds[write_path], 0, i * block_size,
+				      block_size, 0, 0, 0, 0, 0, write_buf,
+				      EXPECT_STATUS_GOOD);
+			if (ret == -2) {
+				logging(LOG_NORMAL,
+					"[SKIPPED] WRITE16 not implemented.");
+				CU_PASS("WRITE16 is not implemented.");
+				return;
+			}
+			CU_ASSERT_EQUAL(ret, 0);
+
+			ret = read16(mp_sds[read_path], NULL, 0, i * block_size,
+				     block_size, 0, 0, 0, 0, 0, read_buf,
+				     EXPECT_STATUS_GOOD);
+			CU_ASSERT_EQUAL(ret, 0);
+
+			/* compare written and read data */
+			CU_ASSERT_EQUAL(0,
+				memcmp(write_buf, read_buf, i * block_size));
+		}
+
+	}
+}


### PR DESCRIPTION
- Add support to iscsi-test-cu for multiple iscsi:// URLs. When multiple are provided, connect to each and check that they correspond to the same logical unit.
- Add a simple multipath IO test that checks for consistent data across multiple paths.

Changes since v1:
- Add tests_multipathio entry to all_suites and scsi_suites.