### PR TITLE
Allow for autogen.sh failure

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -1,5 +1,22 @@
 #!/bin/sh
 
+set -e
+
+needed='rm mkdir autoreconf echo'
+if ! type $needed >/dev/null
+then
+  for cmd in $needed
+  do
+    if ! type $cmd >/dev/null
+    then
+      # Have type print an error message for each missing command
+      type $cmd || true
+    fi
+  done
+  echo A required command is missing. Unable to continue.
+  exit 1
+fi
+
 rm -rf autom4te.cache
 rm -f depcomp aclocal.m4 missing config.guess config.sub install-sh
 rm -f configure config.h.in config.h.in~ m4/libtool.m4 m4/lt*.m4 Makefile.in

--- a/autogen.sh
+++ b/autogen.sh
@@ -4,11 +4,11 @@ set -e
 
 # Commands this script needs
 needed='rm mkdir autoreconf echo'
-if ! type $needed >/dev/null
+if ! type $needed >/dev/null 2>&1
 then
   for cmd in $needed
   do
-    if ! type $cmd >/dev/null
+    if ! type $cmd >/dev/null 2>&1
     then
       # Have type print an error message for each missing command
       type $cmd || true

--- a/autogen.sh
+++ b/autogen.sh
@@ -2,6 +2,7 @@
 
 set -e
 
+# Commands this script needs
 needed='rm mkdir autoreconf echo'
 if ! type $needed >/dev/null
 then


### PR DESCRIPTION
I noticed that if autoconf isn't installed, autogen.sh printed a confusing combination of an error message and instructions to continue, and exited successfully even though it had failed:

```
$ ./autogen.sh 
./autogen.sh: 7: ./autogen.sh: autoreconf: not found
Now run ./configure and then make.
$ echo $?
0
```

This small change to the autogen.sh script allows it to check that the commands it needs are available, and if necessary to report which commands are missing, and exit unsuccessfully.