### PR TITLE
use multipath for secondary sessions (if available) instead of reconnecting

### DIFF
--- a/test-tool/iscsi-multipath.h
+++ b/test-tool/iscsi-multipath.h
@@ -30,6 +30,10 @@ mpath_check_matching_ids(int num_sds,
 int
 mpath_count_iscsi(int num_sds,
 		  struct scsi_device **sds);
+int
+mpath_sd2_get_or_clone(struct scsi_device *sd1, struct scsi_device **_sd2);
+void
+mpath_sd2_put(struct scsi_device *sd2);
 
 #define MPATH_SKIP_IF_UNAVAILABLE(_sds, _num_sds)			\
 do {									\

--- a/test-tool/test_prout_reserve_access.c
+++ b/test-tool/test_prout_reserve_access.c
@@ -22,7 +22,7 @@
 #include "iscsi.h"
 #include "scsi-lowlevel.h"
 #include "iscsi-test-cu.h"
-
+#include "iscsi-multipath.h"
 
 static void
 verify_persistent_reserve_access(struct scsi_device *sd1, struct scsi_device *sd2,
@@ -122,7 +122,8 @@ verify_persistent_reserve_access(struct scsi_device *sd1, struct scsi_device *sd
 void
 test_prout_reserve_access_ea(void)
 {
-	struct scsi_device sd2;
+	struct scsi_device *sd2;
+	int ret;
 
 	if (sd->iscsi_ctx == NULL) {
 		const char *err = "[SKIPPED] This PERSISTENT RESERVE test is "
@@ -132,24 +133,19 @@ test_prout_reserve_access_ea(void)
 		return;
 	}
 
-	memset(&sd2, 0, sizeof(sd2));
-	sd2.iscsi_url = sd->iscsi_url;
-	sd2.iscsi_lun = sd->iscsi_lun;
-	sd2.iscsi_ctx = iscsi_context_login(initiatorname2, sd2.iscsi_url, &sd2.iscsi_lun);
-	if (sd2.iscsi_ctx == NULL) {
-		logging(LOG_VERBOSE, "Failed to login to target");
-		return;
-	}
-	verify_persistent_reserve_access(sd, &sd2,
+	ret = mpath_sd2_get_or_clone(sd, &sd2);
+	CU_ASSERT_EQUAL(ret, 0);
+	verify_persistent_reserve_access(sd, sd2,
 	    SCSI_PERSISTENT_RESERVE_TYPE_EXCLUSIVE_ACCESS,
 	    0, 0, 0, 0);
-	iscsi_destroy_context(sd2.iscsi_ctx);
+	mpath_sd2_put(sd2);
 }
 
 void
 test_prout_reserve_access_we(void)
 {
-	struct scsi_device sd2;
+	struct scsi_device *sd2;
+	int ret;
 
 	if (sd->iscsi_ctx == NULL) {
 		const char *err = "[SKIPPED] This PERSISTENT RESERVE test is "
@@ -159,24 +155,19 @@ test_prout_reserve_access_we(void)
 		return;
 	}
 
-	memset(&sd2, 0, sizeof(sd2));
-	sd2.iscsi_url = sd->iscsi_url;
-	sd2.iscsi_lun = sd->iscsi_lun;
-	sd2.iscsi_ctx = iscsi_context_login(initiatorname2, sd2.iscsi_url, &sd2.iscsi_lun);
-	if (sd2.iscsi_ctx == NULL) {
-		logging(LOG_VERBOSE, "Failed to login to target");
-		return;
-	}
-	verify_persistent_reserve_access(sd, &sd2,
+	ret = mpath_sd2_get_or_clone(sd, &sd2);
+	CU_ASSERT_EQUAL(ret, 0);
+	verify_persistent_reserve_access(sd, sd2,
 	    SCSI_PERSISTENT_RESERVE_TYPE_WRITE_EXCLUSIVE,
 	    1, 0, 1, 0);
-	iscsi_destroy_context(sd2.iscsi_ctx);
+	mpath_sd2_put(sd2);
 }
 
 void
 test_prout_reserve_access_earo(void)
 {
-	struct scsi_device sd2;
+	struct scsi_device *sd2;
+	int ret;
 
 	if (sd->iscsi_ctx == NULL) {
 		const char *err = "[SKIPPED] This PERSISTENT RESERVE test is "
@@ -186,24 +177,19 @@ test_prout_reserve_access_earo(void)
 		return;
 	}
 
-	memset(&sd2, 0, sizeof(sd2));
-	sd2.iscsi_url = sd->iscsi_url;
-	sd2.iscsi_lun = sd->iscsi_lun;
-	sd2.iscsi_ctx = iscsi_context_login(initiatorname2, sd2.iscsi_url, &sd2.iscsi_lun);
-	if (sd2.iscsi_ctx == NULL) {
-		logging(LOG_VERBOSE, "Failed to login to target");
-		return;
-	}
-	verify_persistent_reserve_access(sd, &sd2,
+	ret = mpath_sd2_get_or_clone(sd, &sd2);
+	CU_ASSERT_EQUAL(ret, 0);
+	verify_persistent_reserve_access(sd, sd2,
 	    SCSI_PERSISTENT_RESERVE_TYPE_EXCLUSIVE_ACCESS_REGISTRANTS_ONLY,
 	    1, 1, 0, 0);
-	iscsi_destroy_context(sd2.iscsi_ctx);
+	mpath_sd2_put(sd2);
 }
 
 void
 test_prout_reserve_access_wero(void)
 {
-	struct scsi_device sd2;
+	struct scsi_device *sd2;
+	int ret;
 
 	if (sd->iscsi_ctx == NULL) {
 		const char *err = "[SKIPPED] This PERSISTENT RESERVE test is "
@@ -213,24 +199,19 @@ test_prout_reserve_access_wero(void)
 		return;
 	}
 
-	memset(&sd2, 0, sizeof(sd2));
-	sd2.iscsi_url = sd->iscsi_url;
-	sd2.iscsi_lun = sd->iscsi_lun;
-	sd2.iscsi_ctx = iscsi_context_login(initiatorname2, sd2.iscsi_url, &sd2.iscsi_lun);
-	if (sd2.iscsi_ctx == NULL) {
-		logging(LOG_VERBOSE, "Failed to login to target");
-		return;
-	}
-	verify_persistent_reserve_access(sd, &sd2,
+	ret = mpath_sd2_get_or_clone(sd, &sd2);
+	CU_ASSERT_EQUAL(ret, 0);
+	verify_persistent_reserve_access(sd, sd2,
 	    SCSI_PERSISTENT_RESERVE_TYPE_WRITE_EXCLUSIVE_REGISTRANTS_ONLY,
 	    1, 1, 1, 0);
-	iscsi_destroy_context(sd2.iscsi_ctx);
+	mpath_sd2_put(sd2);
 }
 
 void
 test_prout_reserve_access_eaar(void)
 {
-	struct scsi_device sd2;
+	struct scsi_device *sd2;
+	int ret;
 
 	if (sd->iscsi_ctx == NULL) {
 		const char *err = "[SKIPPED] This PERSISTENT RESERVE test is "
@@ -240,24 +221,19 @@ test_prout_reserve_access_eaar(void)
 		return;
 	}
 
-	memset(&sd2, 0, sizeof(sd2));
-	sd2.iscsi_url = sd->iscsi_url;
-	sd2.iscsi_lun = sd->iscsi_lun;
-	sd2.iscsi_ctx = iscsi_context_login(initiatorname2, sd2.iscsi_url, &sd2.iscsi_lun);
-	if (sd2.iscsi_ctx == NULL) {
-		logging(LOG_VERBOSE, "Failed to login to target");
-		return;
-	}
-	verify_persistent_reserve_access(sd, &sd2,
+	ret = mpath_sd2_get_or_clone(sd, &sd2);
+	CU_ASSERT_EQUAL(ret, 0);
+	verify_persistent_reserve_access(sd, sd2,
 	    SCSI_PERSISTENT_RESERVE_TYPE_EXCLUSIVE_ACCESS_ALL_REGISTRANTS,
 	    1, 1, 0, 0);
-	iscsi_destroy_context(sd2.iscsi_ctx);
+	mpath_sd2_put(sd2);
 }
 
 void
 test_prout_reserve_access_wear(void)
 {
-	struct scsi_device sd2;
+	struct scsi_device *sd2;
+	int ret;
 
 	if (sd->iscsi_ctx == NULL) {
 		const char *err = "[SKIPPED] This PERSISTENT RESERVE test is "
@@ -267,16 +243,10 @@ test_prout_reserve_access_wear(void)
 		return;
 	}
 
-	memset(&sd2, 0, sizeof(sd2));
-	sd2.iscsi_url = sd->iscsi_url;
-	sd2.iscsi_lun = sd->iscsi_lun;
-	sd2.iscsi_ctx = iscsi_context_login(initiatorname2, sd2.iscsi_url, &sd2.iscsi_lun);
-	if (sd2.iscsi_ctx == NULL) {
-		logging(LOG_VERBOSE, "Failed to login to target");
-		return;
-	}
-	verify_persistent_reserve_access(sd, &sd2,
+	ret = mpath_sd2_get_or_clone(sd, &sd2);
+	CU_ASSERT_EQUAL(ret, 0);
+	verify_persistent_reserve_access(sd, sd2,
 	    SCSI_PERSISTENT_RESERVE_TYPE_WRITE_EXCLUSIVE_ALL_REGISTRANTS,
 	    1, 1, 1, 0);
-	iscsi_destroy_context(sd2.iscsi_ctx);
+	mpath_sd2_put(sd2);
 }

--- a/test-tool/test_prout_reserve_ownership.c
+++ b/test-tool/test_prout_reserve_ownership.c
@@ -22,7 +22,7 @@
 #include "iscsi.h"
 #include "scsi-lowlevel.h"
 #include "iscsi-test-cu.h"
-
+#include "iscsi-multipath.h"
 
 static void
 verify_persistent_reserve_ownership(struct scsi_device *sd1, struct scsi_device *sd2,
@@ -96,7 +96,8 @@ verify_persistent_reserve_ownership(struct scsi_device *sd1, struct scsi_device 
 void
 test_prout_reserve_ownership_ea(void)
 {
-	struct scsi_device sd2;
+	struct scsi_device *sd2;
+	int ret;
 
 	if (sd->iscsi_ctx == NULL) {
 		const char *err = "[SKIPPED] This PERSISTENT RESERVE test is "
@@ -106,23 +107,18 @@ test_prout_reserve_ownership_ea(void)
 		return;
 	}
 
-	memset(&sd2, 0, sizeof(sd2));
-	sd2.iscsi_url = sd->iscsi_url;
-	sd2.iscsi_lun = sd->iscsi_lun;
-	sd2.iscsi_ctx = iscsi_context_login(initiatorname2, sd2.iscsi_url, &sd2.iscsi_lun);
-	if (sd2.iscsi_ctx == NULL) {
-		logging(LOG_VERBOSE, "Failed to login to target");
-		return;
-	}
-	verify_persistent_reserve_ownership(sd, &sd2,
+	ret = mpath_sd2_get_or_clone(sd, &sd2);
+	CU_ASSERT_EQUAL(ret, 0);
+	verify_persistent_reserve_ownership(sd, sd2,
 	    SCSI_PERSISTENT_RESERVE_TYPE_EXCLUSIVE_ACCESS, 0);
-	iscsi_destroy_context(sd2.iscsi_ctx);
+	mpath_sd2_put(sd2);
 }
 
 void
 test_prout_reserve_ownership_we(void)
 {
-	struct scsi_device sd2;
+	struct scsi_device *sd2;
+	int ret;
 
 	if (sd->iscsi_ctx == NULL) {
 		const char *err = "[SKIPPED] This PERSISTENT RESERVE test is "
@@ -132,23 +128,18 @@ test_prout_reserve_ownership_we(void)
 		return;
 	}
 
-	memset(&sd2, 0, sizeof(sd2));
-	sd2.iscsi_url = sd->iscsi_url;
-	sd2.iscsi_lun = sd->iscsi_lun;
-	sd2.iscsi_ctx = iscsi_context_login(initiatorname2, sd2.iscsi_url, &sd2.iscsi_lun);
-	if (sd2.iscsi_ctx == NULL) {
-		logging(LOG_VERBOSE, "Failed to login to target");
-		return;
-	}
-	verify_persistent_reserve_ownership(sd, &sd2,
+	ret = mpath_sd2_get_or_clone(sd, &sd2);
+	CU_ASSERT_EQUAL(ret, 0);
+	verify_persistent_reserve_ownership(sd, sd2,
 	    SCSI_PERSISTENT_RESERVE_TYPE_WRITE_EXCLUSIVE, 0);
-	iscsi_destroy_context(sd2.iscsi_ctx);
+	mpath_sd2_put(sd2);
 }
 
 void
 test_prout_reserve_ownership_earo(void)
 {
-	struct scsi_device sd2;
+	struct scsi_device *sd2;
+	int ret;
 
 	if (sd->iscsi_ctx == NULL) {
 		const char *err = "[SKIPPED] This PERSISTENT RESERVE test is "
@@ -158,23 +149,18 @@ test_prout_reserve_ownership_earo(void)
 		return;
 	}
 
-	memset(&sd2, 0, sizeof(sd2));
-	sd2.iscsi_url = sd->iscsi_url;
-	sd2.iscsi_lun = sd->iscsi_lun;
-	sd2.iscsi_ctx = iscsi_context_login(initiatorname2, sd2.iscsi_url, &sd2.iscsi_lun);
-	if (sd2.iscsi_ctx == NULL) {
-		logging(LOG_VERBOSE, "Failed to login to target");
-		return;
-	}
-	verify_persistent_reserve_ownership(sd, &sd2,
+	ret = mpath_sd2_get_or_clone(sd, &sd2);
+	CU_ASSERT_EQUAL(ret, 0);
+	verify_persistent_reserve_ownership(sd, sd2,
 	    SCSI_PERSISTENT_RESERVE_TYPE_EXCLUSIVE_ACCESS_REGISTRANTS_ONLY, 0);
-	iscsi_destroy_context(sd2.iscsi_ctx);
+	mpath_sd2_put(sd2);
 }
 
 void
 test_prout_reserve_ownership_wero(void)
 {
-	struct scsi_device sd2;
+	struct scsi_device *sd2;
+	int ret;
 
 	if (sd->iscsi_ctx == NULL) {
 		const char *err = "[SKIPPED] This PERSISTENT RESERVE test is "
@@ -184,23 +170,18 @@ test_prout_reserve_ownership_wero(void)
 		return;
 	}
 
-	memset(&sd2, 0, sizeof(sd2));
-	sd2.iscsi_url = sd->iscsi_url;
-	sd2.iscsi_lun = sd->iscsi_lun;
-	sd2.iscsi_ctx = iscsi_context_login(initiatorname2, sd2.iscsi_url, &sd2.iscsi_lun);
-	if (sd2.iscsi_ctx == NULL) {
-		logging(LOG_VERBOSE, "Failed to login to target");
-		return;
-	}
-	verify_persistent_reserve_ownership(sd, &sd2,
+	ret = mpath_sd2_get_or_clone(sd, &sd2);
+	CU_ASSERT_EQUAL(ret, 0);
+	verify_persistent_reserve_ownership(sd, sd2,
 	    SCSI_PERSISTENT_RESERVE_TYPE_WRITE_EXCLUSIVE_REGISTRANTS_ONLY, 0);
-	iscsi_destroy_context(sd2.iscsi_ctx);
+	mpath_sd2_put(sd2);
 }
 
 void
 test_prout_reserve_ownership_eaar(void)
 {
-	struct scsi_device sd2;
+	struct scsi_device *sd2;
+	int ret;
 
 	if (sd->iscsi_ctx == NULL) {
 		const char *err = "[SKIPPED] This PERSISTENT RESERVE test is "
@@ -210,23 +191,18 @@ test_prout_reserve_ownership_eaar(void)
 		return;
 	}
 
-	memset(&sd2, 0, sizeof(sd2));
-	sd2.iscsi_url = sd->iscsi_url;
-	sd2.iscsi_lun = sd->iscsi_lun;
-	sd2.iscsi_ctx = iscsi_context_login(initiatorname2, sd2.iscsi_url, &sd2.iscsi_lun);
-	if (sd2.iscsi_ctx == NULL) {
-		logging(LOG_VERBOSE, "Failed to login to target");
-		return;
-	}
-	verify_persistent_reserve_ownership(sd, &sd2,
+	ret = mpath_sd2_get_or_clone(sd, &sd2);
+	CU_ASSERT_EQUAL(ret, 0);
+	verify_persistent_reserve_ownership(sd, sd2,
 	    SCSI_PERSISTENT_RESERVE_TYPE_EXCLUSIVE_ACCESS_ALL_REGISTRANTS, 1);
-	iscsi_destroy_context(sd2.iscsi_ctx);
+	mpath_sd2_put(sd2);
 }
 
 void
 test_prout_reserve_ownership_wear(void)
 {
-	struct scsi_device sd2;
+	struct scsi_device *sd2;
+	int ret;
 
 	if (sd->iscsi_ctx == NULL) {
 		const char *err = "[SKIPPED] This PERSISTENT RESERVE test is "
@@ -236,15 +212,9 @@ test_prout_reserve_ownership_wear(void)
 		return;
 	}
 
-	memset(&sd2, 0, sizeof(sd2));
-	sd2.iscsi_url = sd->iscsi_url;
-	sd2.iscsi_lun = sd->iscsi_lun;
-	sd2.iscsi_ctx = iscsi_context_login(initiatorname2, sd2.iscsi_url, &sd2.iscsi_lun);
-	if (sd2.iscsi_ctx == NULL) {
-		logging(LOG_VERBOSE, "Failed to login to target");
-		return;
-	}
-	verify_persistent_reserve_ownership(sd, &sd2,
+	ret = mpath_sd2_get_or_clone(sd, &sd2);
+	CU_ASSERT_EQUAL(ret, 0);
+	verify_persistent_reserve_ownership(sd, sd2,
 	    SCSI_PERSISTENT_RESERVE_TYPE_WRITE_EXCLUSIVE_ALL_REGISTRANTS, 1);
-	iscsi_destroy_context(sd2.iscsi_ctx);
+	mpath_sd2_put(sd2);
 }

--- a/test-tool/test_reserve6_2initiators.c
+++ b/test-tool/test_reserve6_2initiators.c
@@ -23,16 +23,13 @@
 #include "scsi-lowlevel.h"
 #include "iscsi-support.h"
 #include "iscsi-test-cu.h"
-
+#include "iscsi-multipath.h"
 
 void
 test_reserve6_2initiators(void)
 {
 	int ret;
-	struct scsi_device sd2;
-	memset(&sd2, 0, sizeof(sd2));
-	sd2.iscsi_url = sd->iscsi_url;
-	sd2.iscsi_lun = sd->iscsi_lun;
+	struct scsi_device *sd2;
 
 	logging(LOG_VERBOSE, LOG_BLANK_LINE);
 	logging(LOG_VERBOSE, "Test RESERVE6/RELEASE6 across two initiators");
@@ -59,21 +56,16 @@ test_reserve6_2initiators(void)
 	ret = reserve6(sd);
 	CU_ASSERT_EQUAL(ret, 0);
 
-
-	logging(LOG_VERBOSE, "Create a second connection to the target");
-	sd2.iscsi_ctx = iscsi_context_login(initiatorname2, sd2.iscsi_url, &sd2.iscsi_lun);
-	if (sd2.iscsi_ctx == NULL) {
-		logging(LOG_VERBOSE, "Failed to login to target");
-		return;
-	}
+	ret = mpath_sd2_get_or_clone(sd, &sd2);
+	CU_ASSERT_EQUAL(ret, 0);
 
 	logging(LOG_NORMAL, "Try to take out a RESERVE6 from the second initiator");
-	ret = reserve6_conflict(&sd2);
+	ret = reserve6_conflict(sd2);
 	CU_ASSERT_EQUAL(ret, 0);
 
 
 	logging(LOG_NORMAL, "Try to RELEASE from the second initiator. Should be a nop");
-	ret = release6(&sd2);
+	ret = release6(sd2);
 	CU_ASSERT_EQUAL(ret, 0);
 
 
@@ -83,12 +75,12 @@ test_reserve6_2initiators(void)
 	CU_ASSERT_EQUAL(ret, 0);
 
 	logging(LOG_NORMAL, "MODE SENSE should fail from the second initiator");
-	ret = modesense6(&sd2, NULL, 0, SCSI_MODESENSE_PC_CURRENT, SCSI_MODEPAGE_RETURN_ALL_PAGES, 0, 255,
+	ret = modesense6(sd2, NULL, 0, SCSI_MODESENSE_PC_CURRENT, SCSI_MODEPAGE_RETURN_ALL_PAGES, 0, 255,
 			 EXPECT_RESERVATION_CONFLICT);
 
 
 	logging(LOG_NORMAL, "RESERVE6 from the second initiator should still fail");
-	ret = reserve6_conflict(&sd2);
+	ret = reserve6_conflict(sd2);
 	CU_ASSERT_EQUAL(ret, 0);
 
 	logging(LOG_NORMAL, "RELEASE6 from the first initiator");
@@ -96,13 +88,12 @@ test_reserve6_2initiators(void)
 	CU_ASSERT_EQUAL(ret, 0);
 
 	logging(LOG_NORMAL, "RESERVE6 from the second initiator should work now");
-	ret = reserve6(&sd2);
+	ret = reserve6(sd2);
 	CU_ASSERT_EQUAL(ret, 0);
 
 	logging(LOG_NORMAL, "RELEASE6 from the second initiator");
-	ret = release6(&sd2);
+	ret = release6(sd2);
 	CU_ASSERT_EQUAL(ret, 0);
 
-	iscsi_logout_sync(sd2.iscsi_ctx);
-	iscsi_destroy_context(sd2.iscsi_ctx);
+	mpath_sd2_put(sd2);
 }

--- a/test-tool/test_reserve6_itnexus_loss.c
+++ b/test-tool/test_reserve6_itnexus_loss.c
@@ -23,13 +23,13 @@
 #include "scsi-lowlevel.h"
 #include "iscsi-support.h"
 #include "iscsi-test-cu.h"
-
+#include "iscsi-multipath.h"
 
 void
 test_reserve6_itnexus_loss(void)
 {
 	int ret;
-	struct scsi_device sd2;
+	struct scsi_device *sd2;
 
 	logging(LOG_VERBOSE, LOG_BLANK_LINE);
 	logging(LOG_VERBOSE, "Test that RESERVE6 is released on it-nexus loss");
@@ -53,17 +53,11 @@ test_reserve6_itnexus_loss(void)
 
 
 	logging(LOG_VERBOSE, "Create a second connection to the target");
-	memset(&sd2, 0, sizeof(sd2));
-	sd2.iscsi_url = sd->iscsi_url;
-	sd2.iscsi_lun = sd->iscsi_lun;
-	sd2.iscsi_ctx = iscsi_context_login(initiatorname2, sd2.iscsi_url, &sd2.iscsi_lun);
-	if (sd2.iscsi_ctx == NULL) {
-		logging(LOG_VERBOSE, "Failed to login to target");
-		return;
-	}
+	ret = mpath_sd2_get_or_clone(sd, &sd2);
+	CU_ASSERT_EQUAL(ret, 0);
 
 	logging(LOG_NORMAL, "Try to take out a RESERVE6 from the second initiator");
-	ret = reserve6_conflict(&sd2);
+	ret = reserve6_conflict(sd2);
 	CU_ASSERT_EQUAL(ret, 0);
 
 	logging(LOG_VERBOSE, "Disconnect from the target.");
@@ -80,14 +74,13 @@ test_reserve6_itnexus_loss(void)
 	}
 
 	logging(LOG_NORMAL, "RESERVE6 from the second initiator should work now");
-	ret = reserve6(&sd2);
+	ret = reserve6(sd2);
 	CU_ASSERT_EQUAL(ret, 0);
 
 	logging(LOG_NORMAL, "RELEASE6 from the second initiator");
-	ret = release6(&sd2);
+	ret = release6(sd2);
 	CU_ASSERT_EQUAL(ret, 0);
 
 finished:
-	iscsi_logout_sync(sd2.iscsi_ctx);
-	iscsi_destroy_context(sd2.iscsi_ctx);
+	mpath_sd2_put(sd2);
 }

--- a/test-tool/test_reserve6_logout.c
+++ b/test-tool/test_reserve6_logout.c
@@ -23,13 +23,13 @@
 #include "scsi-lowlevel.h"
 #include "iscsi-support.h"
 #include "iscsi-test-cu.h"
-
+#include "iscsi-multipath.h"
 
 void
 test_reserve6_logout(void)
 {
 	int ret;
-	struct scsi_device sd2;
+	struct scsi_device *sd2;
 
 	logging(LOG_VERBOSE, LOG_BLANK_LINE);
 	logging(LOG_VERBOSE, "Test that RESERVE6 is released on logout");
@@ -53,17 +53,11 @@ test_reserve6_logout(void)
 
 
 	logging(LOG_VERBOSE, "Create a second connection to the target");
-	memset(&sd2, 0, sizeof(sd2));
-	sd2.iscsi_url = sd->iscsi_url;
-	sd2.iscsi_lun = sd->iscsi_lun;
-	sd2.iscsi_ctx = iscsi_context_login(initiatorname2, sd2.iscsi_url, &sd2.iscsi_lun);
-	if (sd2.iscsi_ctx == NULL) {
-		logging(LOG_VERBOSE, "Failed to login to target");
-		return;
-	}
+	ret = mpath_sd2_get_or_clone(sd, &sd2);
+	CU_ASSERT_EQUAL(ret, 0);
 
 	logging(LOG_NORMAL, "Try to take out a RESERVE6 from the second initiator");
-	ret = reserve6_conflict(&sd2);
+	ret = reserve6_conflict(sd2);
 	CU_ASSERT_EQUAL(ret, 0);
 
 	logging(LOG_VERBOSE, "Logout from target");
@@ -78,13 +72,12 @@ test_reserve6_logout(void)
 	}
 
 	logging(LOG_NORMAL, "RESERVE6 from the second initiator should work now");
-	ret = reserve6(&sd2);
+	ret = reserve6(sd2);
 	CU_ASSERT_EQUAL(ret, 0);
 
 	logging(LOG_NORMAL, "RELEASE6 from the second initiator");
-	ret = release6(&sd2);
+	ret = release6(sd2);
 	CU_ASSERT_EQUAL(ret, 0);
 
-	iscsi_logout_sync(sd2.iscsi_ctx);
-	iscsi_destroy_context(sd2.iscsi_ctx);
+	mpath_sd2_put(sd2);
 }

--- a/test-tool/test_reserve6_target_cold_reset.c
+++ b/test-tool/test_reserve6_target_cold_reset.c
@@ -23,13 +23,13 @@
 #include "scsi-lowlevel.h"
 #include "iscsi-support.h"
 #include "iscsi-test-cu.h"
-
+#include "iscsi-multipath.h"
 
 void
 test_reserve6_target_cold_reset(void)
 {
 	int ret;
-	struct scsi_device sd2;
+	struct scsi_device *sd2;
 
 	logging(LOG_VERBOSE, LOG_BLANK_LINE);
 	logging(LOG_VERBOSE, "Test that RESERVE6 is released on target cold reset");
@@ -63,23 +63,16 @@ test_reserve6_target_cold_reset(void)
 	sleep(3);
 
 	logging(LOG_VERBOSE, "Create a second connection to the target");
-	memset(&sd2, 0, sizeof(sd2));
-	sd2.iscsi_url = sd->iscsi_url;
-	sd2.iscsi_lun = sd->iscsi_lun;
-	sd2.iscsi_ctx = iscsi_context_login(initiatorname2, sd2.iscsi_url, &sd2.iscsi_lun);
-	if (sd2.iscsi_ctx == NULL) {
-		logging(LOG_VERBOSE, "Failed to login to target");
-		return;
-	}
+	ret = mpath_sd2_get_or_clone(sd, &sd2);
+	CU_ASSERT_EQUAL(ret, 0);
 
 	logging(LOG_VERBOSE, "RESERVE6 from the second initiator should work now");
-	ret = reserve6(&sd2);
+	ret = reserve6(sd2);
 	CU_ASSERT_EQUAL(ret, 0);
 
 	logging(LOG_VERBOSE, "RELEASE6 from the second initiator");
-	ret = release6(&sd2);
+	ret = release6(sd2);
 	CU_ASSERT_EQUAL(ret, 0);
 
-	iscsi_logout_sync(sd2.iscsi_ctx);
-	iscsi_destroy_context(sd2.iscsi_ctx);
+	mpath_sd2_put(sd2);
 }


### PR DESCRIPTION
<pre>
 test-tool/iscsi-multipath.c                 |  57 +++++++++++
 test-tool/iscsi-multipath.h                 |   4 +
 test-tool/test_preventallow_2_itnexuses.c   |  19 ++--
 test-tool/test_prout_reserve_access.c       | 104 +++++++-------------
 test-tool/test_prout_reserve_ownership.c    | 104 +++++++-------------
 test-tool/test_reserve6_2initiators.c       |  31 +++---
 test-tool/test_reserve6_itnexus_loss.c      |  23 ++---
 test-tool/test_reserve6_logout.c            |  23 ++---
 test-tool/test_reserve6_target_cold_reset.c |  21 ++--
 test-tool/test_reserve6_target_warm_reset.c |  22 ++---
 test-tool/test_sanitize_readonly.c          |  19 ++--
 test-tool/test_sanitize_reservations.c      |  17 ++--
 12 files changed, 195 insertions(+), 249 deletions(-)
</pre>