### PR TITLE
test/pr: fix key deregistration in PRout PREEMPT test

### DIFF
--- a/test-tool/test_prout_preempt.c
+++ b/test-tool/test_prout_preempt.c
@@ -108,14 +108,4 @@ test_prout_preempt_rm_reg(void)
 	/* unregister k2 */
 	ret = prout_register_key(sd2, 0, k2);
 	CU_ASSERT_EQUAL(ret, 0);
-
-	CU_ASSERT_EQUAL(rk->num_keys, 1);
-	/* ensure preempt bumped generation number */
-	CU_ASSERT_EQUAL(rk->prgeneration, old_gen + 1);
-	/* ensure k2 is retained */
-	CU_ASSERT_EQUAL(rk->keys[0], k2);
-
-	/* unregister k2 */
-	ret = prout_register_key(sd2, 0, k2);
-	CU_ASSERT_EQUAL(ret, 0);
 }


### PR DESCRIPTION
Remove duplicate k2 deregistration.

Reported-by: Chris Zankel <czankel@purestorage.com>
Signed-off-by: David Disseldorp <ddiss@suse.de>