### PR TITLE
Socket and iscsi-perf fixes

### DIFF
--- a/lib/socket.c
+++ b/lib/socket.c
@@ -140,7 +140,7 @@ static int set_tcp_sockopt(int sockfd, int optname, int value)
 {
 	int level;
 
-	#if defined(__FreeBSD__) || defined(__sun) || (defined(__APPLE__) && defined(__MACH__))
+	#ifndef SOL_TCP
 	struct protoent *buf;
 
 	if ((buf = getprotobyname("tcp")) != NULL)

--- a/lib/socket.c
+++ b/lib/socket.c
@@ -643,6 +643,13 @@ iscsi_write_to_socket(struct iscsi_context *iscsi)
 	size_t total;
 	struct iscsi_pdu *pdu;
 	static char padding_buf[3];
+	int socket_flags = 0;
+
+#ifdef MSG_NOSIGNAL
+	socket_flags |= MSG_NOSIGNAL;
+#elif SO_NOSIGPIPE
+	socket_flags |= SO_NOSIGPIPE;
+#endif
 
 	if (iscsi->fd == -1) {
 		iscsi_set_error(iscsi, "trying to write but not connected");
@@ -697,7 +704,7 @@ iscsi_write_to_socket(struct iscsi_context *iscsi)
 			count = send(iscsi->fd,
 				     pdu->outdata.data + pdu->outdata_written,
 				     pdu->outdata.size - pdu->outdata_written,
-				     MSG_NOSIGNAL);
+				     socket_flags);
 			if (count == -1) {
 				if (errno == EAGAIN || errno == EWOULDBLOCK) {
 					return 0;
@@ -746,7 +753,7 @@ iscsi_write_to_socket(struct iscsi_context *iscsi)
 
 		/* Write padding */
 		if (pdu->payload_written < total) {
-			count = send(iscsi->fd, padding_buf, total - pdu->payload_written, MSG_NOSIGNAL);
+			count = send(iscsi->fd, padding_buf, total - pdu->payload_written, socket_flags);
 			if (count == -1) {
 				if (errno == EAGAIN || errno == EWOULDBLOCK) {
 					return 0;

--- a/utils/iscsi-perf.c
+++ b/utils/iscsi-perf.c
@@ -14,6 +14,9 @@
    You should have received a copy of the GNU General Public License
    along with this program; if not, see <http://www.gnu.org/licenses/>.
 */
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -32,7 +35,7 @@
 #include <sys/time.h>
 #endif
 
-#define VERSION "0.1"
+#define PERF_VERSION "0.1"
 
 #define NOP_INTERVAL 5
 #define MAX_NOP_FAILURES 3
@@ -77,8 +80,8 @@ uint64_t get_clock_ns(void) {
 
 #ifdef HAVE_CLOCK_GETTIME
 	struct timespec ts;
-	res = clock_gettime (CLOCK_MONOTONIC, &tp);
 	ns = ts.tv_sec * 1000000000 + ts.tv_nsec;
+	res = clock_gettime (CLOCK_MONOTONIC, &ts);
 #else
 	struct timeval tv;
 	res = gettimeofday(&tv, NULL);
@@ -260,7 +263,7 @@ int main(int argc, char *argv[])
 
 	srand(time(NULL));
 	
-	printf("iscsi-perf version %s - (c) 2014-2015 by Peter Lieven <pl@ĸamp.de>\n\n", VERSION);
+	printf("iscsi-perf version %s - (c) 2014-2015 by Peter Lieven <pl@ĸamp.de>\n\n", PERF_VERSION);
 
 	while ((c = getopt_long(argc, argv, "i:m:b:t:nrRx:", long_options,
 			&option_index)) != -1) {

--- a/utils/iscsi-perf.c
+++ b/utils/iscsi-perf.c
@@ -80,12 +80,12 @@ uint64_t get_clock_ns(void) {
 
 #ifdef HAVE_CLOCK_GETTIME
 	struct timespec ts;
-	ns = ts.tv_sec * 1000000000 + ts.tv_nsec;
 	res = clock_gettime (CLOCK_MONOTONIC, &ts);
+	ns = ts.tv_sec * 1000000000ULL + ts.tv_nsec;
 #else
 	struct timeval tv;
 	res = gettimeofday(&tv, NULL);
-	ns = tv.tv_sec * 1000000000 + tv.tv_usec * 1000;
+	ns = tv.tv_sec * 1000000000ULL + tv.tv_usec * 1000;
 #endif
 	if (res == -1) {
 		fprintf(stderr,"could not get requested clock\n");
@@ -98,9 +98,9 @@ void fill_read_queue(struct client *client);
 
 void progress(struct client *client) {
 	uint64_t now = get_clock_ns();
-	if (now - client->last_ns < 1000000000) return;
+	if (now - client->last_ns < 1000000000ULL) return;
 
-	uint64_t _runtime = (now - client->first_ns) / 1000000000UL;
+	uint64_t _runtime = (now - client->first_ns) / 1000000000ULL;
 	if (runtime) _runtime = runtime - _runtime;
 
 	printf ("\r");
@@ -110,8 +110,8 @@ void progress(struct client *client) {
 		finished = 1;
 		printf ("iops average %" PRIu64 " (%" PRIu64 " MB/s)                                                        ", aiops, (aiops * blocks_per_io * client->blocksize) >> 20);
 	} else {
-		uint64_t iops = 1000000000UL * (client->iops - client->last_iops) / (now - client->last_ns);
-		uint64_t mbps = 1000000000UL * (client->bytes - client->last_bytes) / (now - client->last_ns);
+		uint64_t iops = 1000000000ULL * (client->iops - client->last_iops) / (now - client->last_ns);
+		uint64_t mbps = 1000000000ULL * (client->bytes - client->last_bytes) / (now - client->last_ns);
 		printf ("%02" PRIu64 ":%02" PRIu64 ":%02" PRIu64 " - ", _runtime / 3600, (_runtime % 3600) / 60, _runtime % 60);
 		printf ("lba %" PRIu64 ", iops current %" PRIu64 " (%" PRIu64 " MB/s), ", client->pos, iops, mbps >> 20);
 		printf ("iops average %" PRIu64 " (%" PRIu64 " MB/s), in_flight %d, busy %d        ", aiops, ambps >> 20, client->in_flight, client->busy_cnt);


### PR DESCRIPTION
Trying to compile libiscsi was broken on OS X because of the use of the Linux only `MSG_NOSIGNAL` so I've introduced a workaround. The workaround isn't perfect as you get pre-`MSG_NOSIGNAL` behaviour on OSes that don't have `MSG_NOSIGNAL` or `SO_NOSIGPIPE` but the alternative was to mess about with signal handlers (as described on http://stackoverflow.com/questions/2205455/detecting-broken-pipe-in-solaris-send-call ). While in socket.c I simplified the `SOL_TCP` check too.

Next up are a bunch of iscsi-perf fixes to complete the intent from 7c6a3e4 and the addition literal suffixes to fix the weird output (gigantic elapsed times) and behaviour (time limited tests resetting the remaining time part way through) I was seeing using iscsi-perf on a 32 bit Linux system.

PS: The email address printed each time iscsi-perf is run contains an email address for a UTF-8 domain that doesn't exist: @ĸamp.de (this is punycode converted to xn--amp-bva.de ).