### PR TITLE
iscsi: add async abort task test

### DIFF
--- a/include/iscsi.h
+++ b/include/iscsi.h
@@ -595,6 +595,17 @@ enum iscsi_task_mgmt_funcs {
      ISCSI_TM_TASK_REASSIGN     = 0x08
 };
 
+enum iscsi_task_mgmt_response {
+	ISCSI_TMR_FUNC_COMPLETE				= 0x0,
+	ISCSI_TMR_TASK_DOES_NOT_EXIST			= 0x1,
+	ISCSI_TMR_LUN_DOES_NOT_EXIST			= 0x2,
+	ISCSI_TMR_TASK_STILL_ALLEGIANT			= 0x3,
+	ISCSI_TMR_TASK_ALLEGIANCE_REASS_NOT_SUPPORTED	= 0x4,
+	ISCSI_TMR_TMF_NOT_SUPPORTED			= 0x5,
+	ISCSI_TMR_FUNC_AUTH_FAILED			= 0x6,
+	ISCSI_TMR_FUNC_REJECTED				= 0xFF
+};
+
 /*
  * Asynchronous call for task management
  *

--- a/include/iscsi.h
+++ b/include/iscsi.h
@@ -82,6 +82,11 @@ EXTERN int iscsi_service(struct iscsi_context *iscsi, int revents);
  * How many commands are in flight.
  */
 EXTERN int iscsi_queue_length(struct iscsi_context *iscsi);
+/*
+ * How many commands are queued for dispatch.
+ */
+EXTERN int iscsi_out_queue_length(struct iscsi_context *iscsi);
+
 
 /************************************************************
  * Timeout Handling.

--- a/lib/libiscsi.def
+++ b/lib/libiscsi.def
@@ -46,6 +46,7 @@ iscsi_prefetch16_task
 iscsi_preventallow_sync
 iscsi_preventallow_task
 iscsi_queue_length
+iscsi_out_queue_length
 iscsi_queue_pdu
 iscsi_read10_sync
 iscsi_read10_task

--- a/lib/libiscsi.syms
+++ b/lib/libiscsi.syms
@@ -44,6 +44,7 @@ iscsi_prefetch16_task
 iscsi_preventallow_sync
 iscsi_preventallow_task
 iscsi_queue_length
+iscsi_out_queue_length
 iscsi_queue_pdu
 iscsi_read10_sync
 iscsi_read10_task

--- a/lib/socket.c
+++ b/lib/socket.c
@@ -439,6 +439,19 @@ iscsi_queue_length(struct iscsi_context *iscsi)
 	return i;
 }
 
+int
+iscsi_out_queue_length(struct iscsi_context *iscsi)
+{
+	int i = 0;
+	struct iscsi_pdu *pdu;
+
+	for (pdu = iscsi->outqueue; pdu; pdu = pdu->next) {
+		i++;
+	}
+
+	return i;
+}
+
 ssize_t
 iscsi_iovector_readv_writev(struct iscsi_context *iscsi, struct scsi_iovector *iovector, uint32_t pos, ssize_t count, int do_write)
 {


### PR DESCRIPTION
These values are defined in rfc3720
10.6. Task Management Function Response
-> 10.6.1.  Response

The response field is a single byte value, and is already used within
libiscsi as a command_data parameter for iscsi_task_mgmt_async()
callbacks.

Signed-off-by: David Disseldorp <ddiss@suse.de>