### PR TITLE
Fix Qemu Segfault

### DIFF
--- a/include/iscsi-private.h
+++ b/include/iscsi-private.h
@@ -233,8 +233,6 @@ struct iscsi_pdu {
 #define ISCSI_PDU_DROP_ON_RECONNECT	0x00000004
 /* stop sending after this PDU has been sent */
 #define ISCSI_PDU_CORK_WHEN_SENT	0x00000008
-/* Fail the command with error on reconnect */
-#define ISCSI_PDU_ERROR_ON_RECONNECT	0x00000016
 
 	uint32_t flags;
 

--- a/lib/connect.c
+++ b/lib/connect.c
@@ -344,6 +344,10 @@ void iscsi_reconnect_cb(struct iscsi_context *iscsi _U_, int status,
 			 * All other PDUs are discarded at this point.
 			 * This includes DATA-OUT, NOP and task management.
 			 */
+			if (pdu->callback) {
+				pdu->callback(iscsi, SCSI_STATUS_CANCELLED,
+				              NULL, pdu->private_data);
+			}
 			iscsi_free_pdu(old_iscsi, pdu);
 			continue;
 		}

--- a/lib/connect.c
+++ b/lib/connect.c
@@ -338,18 +338,6 @@ void iscsi_reconnect_cb(struct iscsi_context *iscsi _U_, int status,
 			continue;
 		}
 
-		if (pdu->flags & ISCSI_PDU_ERROR_ON_RECONNECT) {
-			/*
-			 * We only want to re-queue SCSI COMMAND PDUs.
-			 * All other PDUs are discarded at this point.
-			 * This includes DATA-OUT, NOP and task management.
-			 */
-			pdu->callback(iscsi, SCSI_STATUS_ERROR, NULL,
-				      pdu->private_data);
-			iscsi_free_pdu(old_iscsi, pdu);
-			continue;
-		}
-
 		if (pdu->flags & ISCSI_PDU_DROP_ON_RECONNECT) {
 			/*
 			 * We only want to re-queue SCSI COMMAND PDUs.

--- a/lib/login.c
+++ b/lib/login.c
@@ -1267,7 +1267,7 @@ iscsi_logout_async(struct iscsi_context *iscsi, iscsi_command_cb cb,
 				 ISCSI_PDU_LOGOUT_REQUEST,
 				 ISCSI_PDU_LOGOUT_RESPONSE,
 				 iscsi_itt_post_increment(iscsi),
-				 ISCSI_PDU_ERROR_ON_RECONNECT|ISCSI_PDU_CORK_WHEN_SENT);
+				 ISCSI_PDU_DROP_ON_RECONNECT|ISCSI_PDU_CORK_WHEN_SENT);
 	if (pdu == NULL) {
 		iscsi_set_error(iscsi, "Out-of-memory: Failed to allocate "
 				"logout pdu.");


### PR DESCRIPTION
Hi Ronnie,

I found Qemu segfaulting on storage timeouts with recent libiscsi. The reason you can find in the commits. I think we should invoke all callbacks of PDUs we drop, shouldn't we?

Peter