### PR TITLE
Fix 2 CHAP related issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,5 @@ TAGS
 /utils/iscsi-readcapacity16
 /utils/iscsi-swp
 /libiscsi.pc
+/.cproject
+/.project

--- a/include/iscsi-private.h
+++ b/include/iscsi-private.h
@@ -63,6 +63,9 @@ void iscsi_free_iscsi_inqueue(struct iscsi_context *iscsi, struct iscsi_in_pdu *
 /* size of chap response field */
 #define CHAP_R_SIZE 16
 
+/* max length of chap challange */
+#define MAX_CHAP_C_LENGTH 2048
+
 struct iscsi_context {
 	char initiator_name[MAX_STRING_SIZE+1];
 	char target_name[MAX_STRING_SIZE+1];
@@ -74,7 +77,7 @@ struct iscsi_context {
 
 	char user[MAX_STRING_SIZE+1];
 	char passwd[MAX_STRING_SIZE+1];
-	char chap_c[MAX_STRING_SIZE+1];
+	char chap_c[MAX_CHAP_C_LENGTH+1];
 
 	char target_user[MAX_STRING_SIZE+1];
 	char target_passwd[MAX_STRING_SIZE+1];

--- a/lib/login.c
+++ b/lib/login.c
@@ -685,14 +685,10 @@ iscsi_login_add_chap_response(struct iscsi_context *iscsi, struct iscsi_pdu *pdu
 		return -1;
 	}
 
-	char chap_r_pbuf[CHAP_R_SIZE*2];
-
 	for (i = 0; i < CHAP_R_SIZE; i++) {
 		c = digest[i];
 		cc[0] = i2h((c >> 4)&0x0f);
 		cc[1] = i2h((c     )&0x0f);
-		chap_r_pbuf[2*i] = cc[0];
-		chap_r_pbuf[2*i+1] = cc[1];
 		if (iscsi_pdu_add_data(iscsi, pdu, &cc[0], 2) != 0) {
 			iscsi_set_error(iscsi, "Out-of-memory: pdu add data "
 				"failed.");

--- a/lib/login.c
+++ b/lib/login.c
@@ -55,8 +55,9 @@ iscsi_login_add_initiatorname(struct iscsi_context *iscsi, struct iscsi_pdu *pdu
 	char str[MAX_STRING_SIZE+1];
 
 	/* We only send InitiatorName during opneg or the first leg of secneg */
-	if (iscsi->current_phase != ISCSI_PDU_LOGIN_CSG_OPNEG
-	&& iscsi->secneg_phase != ISCSI_LOGIN_SECNEG_PHASE_OFFER_CHAP) {
+	if ((iscsi->current_phase != ISCSI_PDU_LOGIN_CSG_OPNEG
+	&& iscsi->secneg_phase != ISCSI_LOGIN_SECNEG_PHASE_OFFER_CHAP)
+	|| iscsi->secneg_phase != ISCSI_LOGIN_SECNEG_PHASE_OFFER_CHAP) {
 		return 0;
 	}
 
@@ -78,8 +79,9 @@ iscsi_login_add_alias(struct iscsi_context *iscsi, struct iscsi_pdu *pdu)
 	char str[MAX_STRING_SIZE+1];
 
 	/* We only send InitiatorAlias during opneg or the first leg of secneg */
-	if (iscsi->current_phase != ISCSI_PDU_LOGIN_CSG_OPNEG
-	&& iscsi->secneg_phase != ISCSI_LOGIN_SECNEG_PHASE_OFFER_CHAP) {
+	if ((iscsi->current_phase != ISCSI_PDU_LOGIN_CSG_OPNEG
+	&& iscsi->secneg_phase != ISCSI_LOGIN_SECNEG_PHASE_OFFER_CHAP)
+	|| iscsi->secneg_phase != ISCSI_LOGIN_SECNEG_PHASE_OFFER_CHAP) {
 		return 0;
 	}
 
@@ -102,8 +104,9 @@ iscsi_login_add_targetname(struct iscsi_context *iscsi, struct iscsi_pdu *pdu)
 	char str[MAX_STRING_SIZE+1];
 
 	/* We only send TargetName during opneg or the first leg of secneg */
-	if (iscsi->current_phase != ISCSI_PDU_LOGIN_CSG_OPNEG
-	&& iscsi->secneg_phase != ISCSI_LOGIN_SECNEG_PHASE_OFFER_CHAP) {
+	if ((iscsi->current_phase != ISCSI_PDU_LOGIN_CSG_OPNEG
+	&& iscsi->secneg_phase != ISCSI_LOGIN_SECNEG_PHASE_OFFER_CHAP)
+	|| iscsi->secneg_phase != ISCSI_LOGIN_SECNEG_PHASE_OFFER_CHAP) {
 		return 0;
 	}
 
@@ -131,9 +134,10 @@ iscsi_login_add_sessiontype(struct iscsi_context *iscsi, struct iscsi_pdu *pdu)
 {
 	char str[MAX_STRING_SIZE+1];
 
-	/* We only send TargetName during opneg or the first leg of secneg */
-	if (iscsi->current_phase != ISCSI_PDU_LOGIN_CSG_OPNEG
-	&& iscsi->secneg_phase != ISCSI_LOGIN_SECNEG_PHASE_OFFER_CHAP) {
+	/* We only send SessionType during opneg or the first leg of secneg */
+	if ((iscsi->current_phase != ISCSI_PDU_LOGIN_CSG_OPNEG
+	&& iscsi->secneg_phase != ISCSI_LOGIN_SECNEG_PHASE_OFFER_CHAP)
+	|| iscsi->secneg_phase != ISCSI_LOGIN_SECNEG_PHASE_OFFER_CHAP) {
 		return 0;
 	}
 

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -1,0 +1,4 @@
+/prog_noop_reply
+/prog_reconnect
+/prog_reconnect_timeout
+/prog_timeout


### PR DESCRIPTION
Hi!

This fixes two CHAP related issues that arise when using FreeNAS. The first is #189 .

#189 is caused by only reading and hashing the first 255 bytes of the CHAP challange.

From https://tools.ietf.org/html/rfc3720#section-11.1.4 :
> ...and C and R are large-binary-values and their binary length (not the length of the character string that represents them in encoded form) MUST not exceed 1024 bytes.

So a target may send a 2K hex string encoding 1K data...

The second issue is FreeNAS not being very lenient when sending too many headers; FreeNAS will immediately close the connection and log an error:
```
Mar 25 10:05:50 freenas ctld[98731]: 192.168.8.156 (iqn.2007-10.com.github:sahlberg:libiscsi:iscsi-inq): initiator resent InitiatorName
Mar 25 10:05:50 freenas ctld[1993]: child process 98731 terminated with exit status 1
```

I've ran `test_1000_chap.sh` and it still works, so `tgt` support is not affected.