### PR TITLE
Silence clang missing-field-initializers warning

### DIFF
--- a/test-tool/test_async_abort_simple.c
+++ b/test-tool/test_async_abort_simple.c
@@ -87,7 +87,7 @@ void
 test_async_abort_simple(void)
 {
 	int ret;
-	struct tests_async_abort_state state = { 0 };
+	struct tests_async_abort_state state = { NULL, 0, 0, 0, 0 };
 	int blocksize = 512;
 	int blocks_per_io = 8;
 	unsigned char buf[blocksize * blocks_per_io];

--- a/test-tool/test_async_read.c
+++ b/test-tool/test_async_read.c
@@ -59,7 +59,7 @@ void
 test_async_read(void)
 {
 	int i, ret;
-	struct tests_async_read_state state = { 0 };
+	struct tests_async_read_state state = { 0, 0, 0 };
 	int blocksize = 512;
 	int blocks_per_io = 8;
 	int num_ios = 1000;

--- a/test-tool/test_async_write.c
+++ b/test-tool/test_async_write.c
@@ -58,7 +58,7 @@ void
 test_async_write(void)
 {
 	int i, ret;
-	struct tests_async_write_state state = { 0 };
+	struct tests_async_write_state state = { 0, 0, 0 };
 	int blocksize = 512;
 	int blocks_per_io = 8;
 	int num_ios = 1000;

--- a/test-tool/test_multipathio_async_caw.c
+++ b/test-tool/test_multipathio_async_caw.c
@@ -102,7 +102,7 @@ test_mpio_async_caw(void)
 {
 	int i, ret;
 	int sd_i;
-	struct test_mpio_async_caw_state state = { 0 };
+	struct test_mpio_async_caw_state state = { 0, 0, 0 };
 	int blocksize = 512;
 	int num_ios = 1000;
 	uint32_t lba = 0;


### PR DESCRIPTION
When libiscsi is built with clang several spurious
missing-field-initializers warnings like the following are reported:

test_async_write.c:61:45: error: missing field 'completed' initializer
[-Werror,-Wmissing-field-initializers]
	struct tests_async_write_state state = { 0 };

These appear to be due to clang being overzealous in its checking
because the code is legal C (see
https://llvm.org/bugs/show_bug.cgi?id=21689 ) but it causes compilation
to be aborted. Workaround the problem by specifying a 0 or NULL for each
structure member.