### PR TITLE
Tests: Ensure each path sends a different initiator when using multipath

### DIFF
--- a/test-tool/iscsi-test-cu.c
+++ b/test-tool/iscsi-test-cu.c
@@ -765,6 +765,7 @@ int
 suite_init(void)
 {
         int i;
+        char const *initiatornames[MPATH_MAX_DEVS] = { initiatorname1, initiatorname2 };
 
         for (i = 0; i < mp_num_sds; i++) {
                 if (!mp_sds[i]->iscsi_url) {
@@ -774,7 +775,7 @@ suite_init(void)
                         iscsi_logout_sync(mp_sds[i]->iscsi_ctx);
                         iscsi_destroy_context(mp_sds[i]->iscsi_ctx);
                 }
-                mp_sds[i]->iscsi_ctx = iscsi_context_login(initiatorname1,
+                mp_sds[i]->iscsi_ctx = iscsi_context_login(initiatornames[i],
                                                         mp_sds[i]->iscsi_url,
                                                         &mp_sds[i]->iscsi_lun);
                 if (mp_sds[i]->iscsi_ctx == NULL) {


### PR DESCRIPTION
Tests such as ProutPreempt presume each path they have is sending a
different initiator name. When using multipath this did not happen and
initiatorname1 was used on all paths.

Fix this by creating and initializing an array (currently size 2) of
initiator names and iterating it in step with each new path we make
(hopefully the compiler will complain if iscsi-test-cu ever supports
more than two multipaths and there isn't a corresponding initiatorname).

Signed-off-by: Sitsofe Wheeler <sitsofe@yahoo.com>