### PR TITLE
tests: add WRITESAME data verification tests

### DIFF
--- a/test-tool/Makefile.am
+++ b/test-tool/Makefile.am
@@ -190,6 +190,7 @@ iscsi_test_cu_SOURCES = iscsi-test-cu.c \
 	test_writesame10_unmap_unaligned.c \
 	test_writesame10_unmap_until_end.c \
 	test_writesame10_unmap_vpd.c \
+	test_writesame10_check.c \
 	test_writesame16_simple.c \
 	test_writesame16_beyond_eol.c \
 	test_writesame16_0blocks.c \
@@ -198,6 +199,7 @@ iscsi_test_cu_SOURCES = iscsi-test-cu.c \
 	test_writesame16_unmap_unaligned.c \
 	test_writesame16_unmap_until_end.c \
 	test_writesame16_unmap_vpd.c \
+	test_writesame16_check.c \
 	test_writeverify10_simple.c \
 	test_writeverify10_beyond_eol.c \
 	test_writeverify10_0blocks.c \

--- a/test-tool/iscsi-test-cu.c
+++ b/test-tool/iscsi-test-cu.c
@@ -419,6 +419,7 @@ static CU_TestInfo tests_writesame10[] = {
         { (char *)"UnmapUnaligned", test_writesame10_unmap_unaligned },
         { (char *)"UnmapUntilEnd", test_writesame10_unmap_until_end },
         { (char *)"UnmapVPD", test_writesame10_unmap_vpd },
+        { (char *)"Check", test_writesame10_check },
         CU_TEST_INFO_NULL
 };
 
@@ -431,6 +432,7 @@ static CU_TestInfo tests_writesame16[] = {
         { (char *)"UnmapUnaligned", test_writesame16_unmap_unaligned },
         { (char *)"UnmapUntilEnd", test_writesame16_unmap_until_end },
         { (char *)"UnmapVPD", test_writesame16_unmap_vpd },
+        { (char *)"Check", test_writesame16_check },
         CU_TEST_INFO_NULL
 };
 

--- a/test-tool/iscsi-test-cu.h
+++ b/test-tool/iscsi-test-cu.h
@@ -272,6 +272,7 @@ void test_writesame10_unmap(void);
 void test_writesame10_unmap_unaligned(void);
 void test_writesame10_unmap_until_end(void);
 void test_writesame10_unmap_vpd(void);
+void test_writesame10_check(void);
 
 void test_writesame16_simple(void);
 void test_writesame16_beyond_eol(void);
@@ -281,6 +282,7 @@ void test_writesame16_unmap(void);
 void test_writesame16_unmap_unaligned(void);
 void test_writesame16_unmap_until_end(void);
 void test_writesame16_unmap_vpd(void);
+void test_writesame16_check(void);
 
 void test_writeverify10_simple(void);
 void test_writeverify10_beyond_eol(void);

--- a/test-tool/test_writesame10_check.c
+++ b/test-tool/test_writesame10_check.c
@@ -1,0 +1,75 @@
+/* -*-  mode:c; tab-width:8; c-basic-offset:8; indent-tabs-mode:nil;  -*- */
+/*
+   Copyright (C) 2016 David Disseldorp
+   Copyright (C) 2013 Ronnie Sahlberg <ronniesahlberg@gmail.com>
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; either version 2 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program; if not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <stdio.h>
+#include <stdlib.h>
+
+#include <CUnit/CUnit.h>
+
+#include "iscsi.h"
+#include "scsi-lowlevel.h"
+#include "iscsi-support.h"
+#include "iscsi-test-cu.h"
+
+
+void
+test_writesame10_check(void)
+{
+	int i;
+	int ws_max_blocks = 256;
+	char read_buf[ws_max_blocks * block_size];
+
+	CHECK_FOR_DATALOSS;
+	CHECK_FOR_SBC;
+
+	logging(LOG_VERBOSE, LOG_BLANK_LINE);
+	logging(LOG_VERBOSE, "Test WRITESAME10 of 1-256 blocks at the start of the LUN");
+
+	for (i = 1; i <= ws_max_blocks; i++) {
+		/*
+		 * fill the full buffer so that memcmp is straightforward,
+		 * even though writesame is only using one block of it.
+		 */
+		memset(scratch, i, block_size * ws_max_blocks);
+		WRITESAME10(sd, 0, block_size, i, 0, 0, 0, 0, scratch,
+			    EXPECT_STATUS_GOOD);
+
+		memset(read_buf, 0, i * block_size);
+		READ10(sd, NULL, 0, i * block_size,
+		       block_size, 0, 0, 0, 0, 0, read_buf,
+		       EXPECT_STATUS_GOOD);
+
+		CU_ASSERT_EQUAL(0, memcmp(read_buf, scratch, i));
+	}
+
+	logging(LOG_VERBOSE, "Test WRITESAME10 of 1-256 blocks at the end of the LUN");
+	for (i = 1; i <= ws_max_blocks; i++) {
+		memset(scratch, i, block_size * ws_max_blocks);
+		WRITESAME10(sd, num_blocks - i,
+			    block_size, i, 0, 0, 0, 0, scratch,
+			    EXPECT_STATUS_GOOD);
+
+		memset(read_buf, 0, i * block_size);
+		READ10(sd, NULL, num_blocks - i, i * block_size,
+		       block_size, 0, 0, 0, 0, 0, read_buf,
+		       EXPECT_STATUS_GOOD);
+
+		CU_ASSERT_EQUAL(0, memcmp(read_buf, scratch, i));
+	}
+}

--- a/test-tool/test_writesame16_check.c
+++ b/test-tool/test_writesame16_check.c
@@ -1,0 +1,75 @@
+/* -*-  mode:c; tab-width:8; c-basic-offset:8; indent-tabs-mode:nil;  -*- */
+/*
+   Copyright (C) 2016 David Disseldorp
+   Copyright (C) 2013 Ronnie Sahlberg <ronniesahlberg@gmail.com>
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; either version 2 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program; if not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <stdio.h>
+#include <stdlib.h>
+
+#include <CUnit/CUnit.h>
+
+#include "iscsi.h"
+#include "scsi-lowlevel.h"
+#include "iscsi-support.h"
+#include "iscsi-test-cu.h"
+
+
+void
+test_writesame16_check(void)
+{
+	int i;
+	int ws_max_blocks = 256;
+	char read_buf[ws_max_blocks * block_size];
+
+	CHECK_FOR_DATALOSS;
+	CHECK_FOR_SBC;
+
+	logging(LOG_VERBOSE, LOG_BLANK_LINE);
+	logging(LOG_VERBOSE, "Test WRITESAME16 of 1-256 blocks at the start of the LUN");
+
+	for (i = 1; i <= ws_max_blocks; i++) {
+		/*
+		 * fill the full buffer so that memcmp is straightforward,
+		 * even though writesame is only using one block of it.
+		 */
+		memset(scratch, i, block_size * ws_max_blocks);
+		WRITESAME16(sd, 0, block_size, i, 0, 0, 0, 0, scratch,
+			    EXPECT_STATUS_GOOD);
+
+		memset(read_buf, 0, i * block_size);
+		READ16(sd, NULL, 0, i * block_size,
+		       block_size, 0, 0, 0, 0, 0, read_buf,
+		       EXPECT_STATUS_GOOD);
+
+		CU_ASSERT_EQUAL(0, memcmp(read_buf, scratch, i));
+	}
+
+	logging(LOG_VERBOSE, "Test WRITESAME16 of 1-256 blocks at the end of the LUN");
+	for (i = 1; i <= ws_max_blocks; i++) {
+		memset(scratch, i, block_size * ws_max_blocks);
+		WRITESAME16(sd, num_blocks - i,
+			    block_size, i, 0, 0, 0, 0, scratch,
+			    EXPECT_STATUS_GOOD);
+
+		memset(read_buf, 0, i * block_size);
+		READ16(sd, NULL, num_blocks - i, i * block_size,
+		       block_size, 0, 0, 0, 0, 0, read_buf,
+		       EXPECT_STATUS_GOOD);
+
+		CU_ASSERT_EQUAL(0, memcmp(read_buf, scratch, i));
+	}
+}


### PR DESCRIPTION
Based on the corresponding simple tests. Issue a WRITESAME request and
confirm that the data written matches the data read back.

Signed-off-by: David Disseldorp <ddiss@suse.de>