### PR TITLE
Tests: WRITESAME 0-blocks fixes and improvements

### DIFF
--- a/test-tool/iscsi-support.h
+++ b/test-tool/iscsi-support.h
@@ -181,6 +181,16 @@ do {                                                                        \
         }                                                                \
 } while (0);
 
+#define CHECK_SIZE(_min_blocks, _c)                                     \
+        do {                                                            \
+                if (num_blocks < _min_blocks) {                         \
+                        logging(LOG_VERBOSE, "[SKIPPED] "               \
+                                "LUN too small. Skipping assert");      \
+                } else {                                                \
+                        _c                                              \
+                }                                                       \
+        } while (0);
+
 #define COMPAREANDWRITE(...)                                            \
         do {                                                            \
                 int _r;                                                 \


### PR DESCRIPTION
The current WRITE SAME (WS) 0 blocks test at LBA 0 isn't always correct
because if:
- The target's WSNZ bit set is 0
- The target's MAXIMUM WRITE SAME LENGTH (MWSL) is greater than 0
- We are issuing a WS with a NUMBER OF LOGICAL BLOCKS of 0

then whether the command should return success or failure depends on
whether the starting LBA is within MWSL blocks of the end of the LUN
(see http://www.t10.org/pipermail/t10/2016-May/017988.html for details).

Replace the vestigial code which tried to handle this (but no longer
worked since commit 8585e4509b72c9d1e8f814d67d53847a75c6a535 ) and add
some additional MAXIMUM WRITE SAME LENGTH tests.

Signed-off-by: Sitsofe Wheeler <sitsofe@yahoo.com>

CC'ing @ddiss, @bvanassche .