### PR TITLE
lib: Remove unused iscsi_queue_pdu symbol

### DIFF
--- a/lib/libiscsi.def
+++ b/lib/libiscsi.def
@@ -48,7 +48,6 @@ iscsi_preventallow_sync
 iscsi_preventallow_task
 iscsi_queue_length
 iscsi_out_queue_length
-iscsi_queue_pdu
 iscsi_read10_sync
 iscsi_read10_iov_sync
 iscsi_read10_task

--- a/lib/libiscsi.syms
+++ b/lib/libiscsi.syms
@@ -46,7 +46,6 @@ iscsi_preventallow_sync
 iscsi_preventallow_task
 iscsi_queue_length
 iscsi_out_queue_length
-iscsi_queue_pdu
 iscsi_read10_sync
 iscsi_read10_iov_sync
 iscsi_read10_task


### PR DESCRIPTION
Remove iscsi_queue_pdu from the list of symbols otherwise clang on OSX
fails to compile with the following error:

Undefined symbols for architecture x86_64:
  "_iscsi_queue_pdu", referenced from:
     -exported_symbol[s_list] command line option
ld: symbol(s) not found for architecture x86_64
clang: error: linker command failed with exit code 1 (use -v to see invocation)