### PR TITLE
Update a URL in README, fix a typo there too

### DIFF
--- a/README
+++ b/README
@@ -196,7 +196,7 @@ These names can be controlled by using the arguments
 The tests are all self-documented to describe what they test and how they test.
 Use -V with a test to print the documentation for a test.
 
-XLM/JUNIT
+XML/JUNIT
 =========
 iscsi-test-cu can produce machine-readable test results for consumption by your
 CI server. Use the --xml option with any test suite(s), and a file called

--- a/README
+++ b/README
@@ -203,7 +203,7 @@ CI server. Use the --xml option with any test suite(s), and a file called
 CUnitAutomated-Results.xml will be written to your current working directory.
 These results can be converted to JUnit format using this script:
 
-http://git.cyrusimap.org/cyrus-imapd/plain/cunit/cunit-to-junit.pl
+https://raw.githubusercontent.com/cyrusimap/cyrus-imapd/master/cunit/cunit-to-junit.pl
 
 See also:
 


### PR DESCRIPTION
cyrus-imapd project, where the README links to, has migrated their repo to github per: https://cgit.cyrus.foundation/cyrus-imapd/tree/README.TXT and the old link throws a 404:

```bash
$ curl -sv https://cgit.cyrus.foundation/cyrus-imapd/plain/cunit/cunit-to-junit.pl 2>&1 | grep 'HTTP/1.1'
> GET /cyrus-imapd/plain/cunit/cunit-to-junit.pl HTTP/1.1
< HTTP/1.1 404 Not found
```

Updated the README with new [URL](https://raw.githubusercontent.com/cyrusimap/cyrus-imapd/master/cunit/cunit-to-junit.pl), and fix a small typo