### PR TITLE
TESTS: drop /dev/sg device path check for iSCSI

### DIFF
--- a/test-tool/iscsi-test-cu.c
+++ b/test-tool/iscsi-test-cu.c
@@ -1446,7 +1446,7 @@ main(int argc, char *argv[])
          * of sectors here. Just force it to 120k and let us get on with
          * our lives.
          */
-        if (!strncmp(sd->sgio_dev, "/dev/sg", 7)) {
+        if (sd->sgio_dev && !strncmp(sd->sgio_dev, "/dev/sg", 7)) {
                 printf("Looks like a /dev/sg device. Force max iosize "
                        "to 120k as BLKSECTGET is just broken and can "
                        "not be used for discovery.\n");


### PR DESCRIPTION
When run against an iSCSI target sd->sgio_dev may be NULL, so the
strncmp() coredumps.

Fixes: 698ae7a649e66a44f398cd35c9ac2118f7411487

Signed-off-by: David Disseldorp <ddiss@suse.de>