### PR TITLE
Do not use -I/usr/include. This is unsafe when cross-compiling.

### DIFF
--- a/examples/Makefile.am
+++ b/examples/Makefile.am
@@ -1,6 +1,6 @@
 AM_CPPFLAGS=-I. -I${srcdir}/../include "-D_U_=__attribute__((unused))" \
 	"-D_R_(A,B)=__attribute__((format(printf,A,B)))"
-AM_CFLAGS=$(WARN_CFLAGS) -I/usr/include
+AM_CFLAGS=$(WARN_CFLAGS)
 LDADD = ../lib/libiscsi.la
 
 noinst_PROGRAMS = iscsiclient iscsi-dd

--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -29,7 +29,7 @@ libiscsi_la_CPPFLAGS = -I${srcdir}/../include -I$(srcdir)/include \
 	"-D_U_=__attribute__((unused))" \
 	"-D_R_(A,B)=__attribute__((format(printf,A,B)))"
 
-AM_CFLAGS=$(WARN_CFLAGS) -I/usr/include
+AM_CFLAGS=$(WARN_CFLAGS)
 
 dist_noinst_DATA = libiscsi.syms libiscsi.def
 

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -1,6 +1,6 @@
 AM_CPPFLAGS = -I../include "-D_U_=__attribute__((unused))" \
 	"-D_R_(A,B)=__attribute__((format(printf,A,B)))"
-AM_CFLAGS = $(WARN_CFLAGS) -I/usr/include
+AM_CFLAGS = $(WARN_CFLAGS)
 LDADD = ../lib/libiscsi.la
 
 noinst_PROGRAMS = prog_reconnect prog_reconnect_timeout prog_noop_reply \

--- a/utils/Makefile.am
+++ b/utils/Makefile.am
@@ -1,6 +1,6 @@
 AM_CPPFLAGS = -I${srcdir}/../include "-D_U_=__attribute__((unused))" \
 	"-D_R_(A,B)=__attribute__((format(printf,A,B)))"
-AM_CFLAGS = $(WARN_CFLAGS) -I/usr/include
+AM_CFLAGS = $(WARN_CFLAGS)
 LDADD = ../lib/libiscsi.la
 
 bin_PROGRAMS = iscsi-inq iscsi-ls iscsi-perf iscsi-readcapacity16 \


### PR DESCRIPTION
Signed-off-by: Vicente Olivert Riera Vincent.Riera@imgtec.com
