### PR TITLE
adds max block descriptor count control to Unmap; skips Verify on LBA…

### DIFF
--- a/test-tool/test_unmap_0blocks.c
+++ b/test-tool/test_unmap_0blocks.c
@@ -30,6 +30,7 @@ void
 test_unmap_0blocks(void)
 {
         int i;
+        int max_nr_bdc = 256;
         struct unmap_list list[257];
 
         CHECK_FOR_DATALOSS;
@@ -60,19 +61,23 @@ test_unmap_0blocks(void)
                 return;
         }
 
-        logging(LOG_VERBOSE, "Test UNMAP of 0 blocks at LBA:0-255  with one descriptor per block");
-        for (i = 0; i < 256; i++) {
+        if (inq_bl->max_unmap_bdc > 0 && max_nr_bdc > (int)inq_bl->max_unmap_bdc) {
+          max_nr_bdc = (int)inq_bl->max_unmap_bdc;
+        }
+
+        logging(LOG_VERBOSE, "Test UNMAP of 0 blocks at LBA:0-%d  with one descriptor per block", max_nr_bdc - 1);
+        for (i = 0; i < max_nr_bdc; i++) {
                 list[i].lba = i;
                 list[i].num = 0;
                 UNMAP(sd, 0, list, i + 1,
                       EXPECT_STATUS_GOOD);
         }
 
-        logging(LOG_VERBOSE, "Test UNMAP of 0 blocks at LBA:0-255  with one descriptor per block, possibly \"overlapping\".");
-        for (i = 0; i < 256; i++) {
+        logging(LOG_VERBOSE, "Test UNMAP of 0 blocks at LBA:0-%d  with one descriptor per block, possibly \"overlapping\".", max_nr_bdc - 1);
+        for (i = 0; i < max_nr_bdc; i++) {
                 list[i].lba = i/2;
                 list[i].num = 0;
         }
-        UNMAP(sd, 0, list, 256,
+        UNMAP(sd, 0, list, max_nr_bdc,
               EXPECT_STATUS_GOOD);
 }

--- a/test-tool/test_verify10_0blocks.c
+++ b/test-tool/test_verify10_0blocks.c
@@ -34,9 +34,11 @@ test_verify10_0blocks(void)
         VERIFY10(sd, num_blocks + 1, 0, block_size, 0, 0, 1, NULL,
                  EXPECT_LBA_OOB);
 
-        logging(LOG_VERBOSE, "Test VERIFY10 0-blocks at LBA==2^31");
-        VERIFY10(sd, 0x80000000, 0, block_size, 0, 0, 1, NULL,
-                 EXPECT_LBA_OOB);
+        if (num_blocks - 1 < 0x80000000) {
+          logging(LOG_VERBOSE, "Test VERIFY10 0-blocks at LBA==2^31");
+          VERIFY10(sd, 0x80000000, 0, block_size, 0, 0, 1, NULL,
+                   EXPECT_LBA_OOB);
+        }
 
         logging(LOG_VERBOSE, "Test VERIFY10 0-blocks at LBA==-1");
         VERIFY10(sd, -1, 0, block_size, 0, 0, 1, NULL,

--- a/test-tool/test_verify12_0blocks.c
+++ b/test-tool/test_verify12_0blocks.c
@@ -34,9 +34,11 @@ test_verify12_0blocks(void)
         VERIFY12(sd, num_blocks + 1, 0, block_size, 0, 0, 1, NULL,
                  EXPECT_LBA_OOB);
 
-        logging(LOG_VERBOSE, "Test VERIFY12 0-blocks at LBA==2^31");
-        VERIFY12(sd, 0x80000000, 0, block_size, 0, 0, 1, NULL,
-                 EXPECT_LBA_OOB);
+        if (num_blocks - 1 < 0x80000000) {
+          logging(LOG_VERBOSE, "Test VERIFY12 0-blocks at LBA==2^31");
+          VERIFY12(sd, 0x80000000, 0, block_size, 0, 0, 1, NULL,
+                   EXPECT_LBA_OOB);
+        }
 
         logging(LOG_VERBOSE, "Test VERIFY12 0-blocks at LBA==-1");
         VERIFY12(sd, -1, 0, block_size, 0, 0, 1, NULL,


### PR DESCRIPTION
… 2^31 if that LBA is valid (not outside the LUN)
