### PR TITLE
Remember the id of the async task to be freed, to avoid crash in case…

### DIFF
--- a/include/iscsi-private.h
+++ b/include/iscsi-private.h
@@ -75,6 +75,14 @@ union socket_address {
 	struct sockaddr sa;
 };
 
+/* size of list holding ids (ITT) of freed async commands */
+#define FREED_ASYNC_CMDS_CAPACITY 5
+
+struct freed_async_cmds {
+	uint32_t nr_cmds;
+	uint32_t cmd_itts[FREED_ASYNC_CMDS_CAPACITY];
+};
+
 struct iscsi_context {
 	struct iscsi_transport *drv;
 	void *opaque;
@@ -176,6 +184,8 @@ struct iscsi_context {
 	struct iscsi_context *old_iscsi;
 	int retry_cnt;
 	int no_ua_on_reconnect;
+
+	struct freed_async_cmds async_freed;
 };
 
 #define ISCSI_PDU_IMMEDIATE		       0x40

--- a/test-tool/iscsi-support.c
+++ b/test-tool/iscsi-support.c
@@ -3121,3 +3121,16 @@ test_get_clock_sec(void)
 	assert(res == 0);
 	return secs;
 }
+
+/* Stores the id of the task to be freed, to avoid crash in case of late response (callback on a freed task) */
+int
+iscsi_set_task_freed(struct scsi_device *iscsi_sd, uint32_t itt)
+{   
+    if (iscsi_sd->iscsi_ctx->async_freed.nr_cmds < FREED_ASYNC_CMDS_CAPACITY) {
+        iscsi_sd->iscsi_ctx->async_freed.cmd_itts[iscsi_sd->iscsi_ctx->async_freed.nr_cmds] = itt;
+        iscsi_sd->iscsi_ctx->async_freed.nr_cmds++;
+        return 1;
+    }
+    
+    return 0;
+}

--- a/test-tool/iscsi-support.h
+++ b/test-tool/iscsi-support.h
@@ -914,4 +914,6 @@ int test_iscsi_tur_until_good(struct scsi_device *iscsi_sd, int *num_uas);
 
 uint64_t test_get_clock_sec(void);
 
+int iscsi_set_task_freed(struct scsi_device *iscsi_sd, uint32_t itt);
+
 #endif        /* _ISCSI_SUPPORT_H_ */

--- a/test-tool/test_async_lu_reset_simple.c
+++ b/test-tool/test_async_lu_reset_simple.c
@@ -191,5 +191,9 @@ test_async_lu_reset_simple(void)
 		CU_FAIL("unexpected WRITE/RESET state");
 	}
 
+	if (iscsi_set_task_freed(sd, state.wtask->itt) == 0) {
+		logging(LOG_VERBOSE, "Cannot add to freed async commands list (list full)");
+	}
+
 	scsi_free_scsi_task(state.wtask);
 }


### PR DESCRIPTION
… of late response (callback on a freed task)

THE PROBLEM: While running the test case ALL.iSCSITMF.LUNResetSimpleAsync I have experienced the following scenario:
1) both Write and LU_Reset commands complete successfully on target
2) the LU_Reset response arrives first to the initiator (libiscsi)
3) libiscsi frees the memory of the async Write task, not expecting any response to it, since the LU was just reset and this means, among other things, "abort all tasks"
4) the Write response arrives a bit late, while the initiator is still in the process of logging out, but not yet done
5) libiscsi crashes (segmentation fault) while processing the callback for the Write task, because the task has already been freed

THE SOLUTION I suggest: store the unique ids (ITT) of the async tasks before freeing them, and check in the callback handling area if the respective task has already been freed. If yes, just ignore the response (the response is anyway useless at that point, as the test case has already been completed) and avoid crashing.

The sequence of iSCSI requests and responses that I am describing is visible in the capture below:

![capture](https://cloud.githubusercontent.com/assets/7999253/20433069/5875fef0-ada2-11e6-8fd1-e209d6725bce.JPG)
