### PR TITLE
fix crc32c header checksums and some bugs

### DIFF
--- a/include/iscsi-private.h
+++ b/include/iscsi-private.h
@@ -355,7 +355,7 @@ void* iscsi_smalloc(struct iscsi_context *iscsi, size_t size);
 void* iscsi_szmalloc(struct iscsi_context *iscsi, size_t size);
 void iscsi_sfree(struct iscsi_context *iscsi, void* ptr);
 
-unsigned long crc32c(char *buf, int len);
+uint32_t crc32c(uint8_t *buf, int len);
 
 struct scsi_task *iscsi_scsi_get_task_from_pdu(struct iscsi_pdu *pdu);
 

--- a/include/iscsi-private.h
+++ b/include/iscsi-private.h
@@ -351,6 +351,7 @@ void* iscsi_zmalloc(struct iscsi_context *iscsi, size_t size);
 void* iscsi_realloc(struct iscsi_context *iscsi, void* ptr, size_t size);
 void iscsi_free(struct iscsi_context *iscsi, void* ptr);
 char* iscsi_strdup(struct iscsi_context *iscsi, const char* str);
+void* iscsi_smalloc(struct iscsi_context *iscsi, size_t size);
 void* iscsi_szmalloc(struct iscsi_context *iscsi, size_t size);
 void iscsi_sfree(struct iscsi_context *iscsi, void* ptr);
 

--- a/lib/crc32c.c
+++ b/lib/crc32c.c
@@ -43,7 +43,7 @@
 /*                                                               */
 /*****************************************************************/
 
-static unsigned long crctable[256] = {
+uint32_t crctable[256] = {
  0x00000000L, 0xF26B8303L, 0xE13B70F7L, 0x1350F3F4L,
  0xC79A971FL, 0x35F1141CL, 0x26A1E7E8L, 0xD4CA64EBL,
  0x8AD958CFL, 0x78B2DBCCL, 0x6BE22838L, 0x9989AB3BL,
@@ -110,9 +110,9 @@ static unsigned long crctable[256] = {
  0xBE2DA0A5L, 0x4C4623A6L, 0x5F16D052L, 0xAD7D5351L
 };
 
-unsigned long crc32c(char *buf, int len)
+uint32_t crc32c(uint8_t *buf, int len)
 {
-	unsigned long crc = 0xffffffff;
+	uint32_t crc = 0xffffffff;
 	while (len-- > 0) {
 		crc = (crc>>8) ^ crctable[(crc ^ (*buf++)) & 0xFF];
 	}

--- a/lib/init.c
+++ b/lib/init.c
@@ -111,15 +111,22 @@ char* iscsi_strdup(struct iscsi_context *iscsi, const char* str) {
 	return str2;
 }
 
-void* iscsi_szmalloc(struct iscsi_context *iscsi, size_t size) {
+void* iscsi_smalloc(struct iscsi_context *iscsi, size_t size) {
 	void *ptr;
 	if (size > iscsi->smalloc_size) return NULL;
 	if (iscsi->smalloc_free > 0) {
 		ptr = iscsi->smalloc_ptrs[--iscsi->smalloc_free];
-		memset(ptr, 0, iscsi->smalloc_size);
 		iscsi->smallocs++;
 	} else {
-		ptr = iscsi_zmalloc(iscsi, iscsi->smalloc_size);
+		ptr = iscsi_malloc(iscsi, iscsi->smalloc_size);
+	}
+	return ptr;
+}
+
+void* iscsi_szmalloc(struct iscsi_context *iscsi, size_t size) {
+	void *ptr = iscsi_smalloc(iscsi, size);
+	if (ptr) {
+		memset(ptr, 0, size);
 	}
 	return ptr;
 }

--- a/lib/login.c
+++ b/lib/login.c
@@ -1217,6 +1217,8 @@ iscsi_process_login_reply(struct iscsi_context *iscsi, struct iscsi_pdu *pdu,
 			must_have_chap_r = 0;
 		}
 
+		ISCSI_LOG(iscsi, 6, "TargetLoginReply: %s", ptr);
+
 		ptr  += len + 1;
 		size -= len + 1;
 	}

--- a/lib/socket.c
+++ b/lib/socket.c
@@ -677,7 +677,7 @@ iscsi_read_from_socket(struct iscsi_context *iscsi)
 
 static int iscsi_pdu_update_headerdigest(struct iscsi_context *iscsi, struct iscsi_pdu *pdu)
 {
-	unsigned long crc;
+	uint32_t crc;
 
 	if (pdu->outdata.size < ISCSI_RAW_HEADER_SIZE + ISCSI_DIGEST_SIZE) {
 		iscsi_set_error(iscsi, "PDU too small (%u) to contain header digest",
@@ -685,12 +685,12 @@ static int iscsi_pdu_update_headerdigest(struct iscsi_context *iscsi, struct isc
 		return -1;
 	}
 
-	crc = crc32c((char *)pdu->outdata.data, ISCSI_RAW_HEADER_SIZE);
+	crc = crc32c(pdu->outdata.data, ISCSI_RAW_HEADER_SIZE);
 
-	pdu->outdata.data[ISCSI_RAW_HEADER_SIZE+3] = (crc >> 24)&0xff;
-	pdu->outdata.data[ISCSI_RAW_HEADER_SIZE+2] = (crc >> 16)&0xff;
-	pdu->outdata.data[ISCSI_RAW_HEADER_SIZE+1] = (crc >>  8)&0xff;
-	pdu->outdata.data[ISCSI_RAW_HEADER_SIZE+0] = (crc)      &0xff;
+	pdu->outdata.data[ISCSI_RAW_HEADER_SIZE+3] = (crc >> 24);
+	pdu->outdata.data[ISCSI_RAW_HEADER_SIZE+2] = (crc >> 16);
+	pdu->outdata.data[ISCSI_RAW_HEADER_SIZE+1] = (crc >>  8);
+	pdu->outdata.data[ISCSI_RAW_HEADER_SIZE+0] = (crc);
 	return 0;
 }
 

--- a/lib/socket.c
+++ b/lib/socket.c
@@ -979,7 +979,7 @@ static int iscsi_tcp_queue_pdu(struct iscsi_context *iscsi,
 void
 iscsi_free_iscsi_in_pdu(struct iscsi_context *iscsi, struct iscsi_in_pdu *in)
 {
-	iscsi_free(iscsi, in->hdr);
+	iscsi_sfree(iscsi, in->hdr);
 	iscsi_free(iscsi, in->data);
 	in->data=NULL;
 	iscsi_sfree(iscsi, in);

--- a/lib/socket.c
+++ b/lib/socket.c
@@ -570,7 +570,7 @@ iscsi_read_from_socket(struct iscsi_context *iscsi)
 
 	if (iscsi->incoming == NULL) {
 		iscsi->incoming = iscsi_szmalloc(iscsi, sizeof(struct iscsi_in_pdu));
-		iscsi->incoming->hdr = iscsi_szmalloc(iscsi, ISCSI_RAW_HEADER_SIZE + ISCSI_DIGEST_SIZE);
+		iscsi->incoming->hdr = iscsi_smalloc(iscsi, ISCSI_HEADER_SIZE);
 		if (iscsi->incoming == NULL) {
 			iscsi_set_error(iscsi, "Out-of-memory: failed to malloc iscsi_in_pdu");
 			return -1;

--- a/lib/socket.c
+++ b/lib/socket.c
@@ -366,6 +366,7 @@ iscsi_connect_async(struct iscsi_context *iscsi, const char *portal,
 	}
 
 	freeaddrinfo(ai);
+	strncpy(iscsi->connected_portal, portal, MAX_STRING_SIZE);
 	return 0;
 }
 


### PR DESCRIPTION
@sahlberg as discussed
@shterman as far as i read the iser code it does not support header checksums. we should abort then if the target requests HeaderDigest=CRC32C