### PR TITLE
test tool: Set BYTCHK=1 if EDTL != 0

### DIFF
--- a/test-tool/test_nomedia_sbc.c
+++ b/test-tool/test_nomedia_sbc.c
@@ -93,7 +93,7 @@ static void
 test_writeverify10(void)
 {
         logging(LOG_VERBOSE, "Test WRITEVERIFY10 when medium is ejected.");
-        WRITEVERIFY10(sd, 0, block_size, block_size, 0, 0, 0, 0, scratch,
+        WRITEVERIFY10(sd, 0, block_size, block_size, 0, 0, 1, 0, scratch,
                       EXPECT_NO_MEDIUM);
 }
 
@@ -101,7 +101,7 @@ static void
 test_writeverify12(void)
 {
         logging(LOG_VERBOSE, "Test WRITEVERIFY12 when medium is ejected.");
-        WRITEVERIFY12(sd, 0, block_size, block_size, 0, 0, 0, 0, scratch,
+        WRITEVERIFY12(sd, 0, block_size, block_size, 0, 0, 1, 0, scratch,
                       EXPECT_NO_MEDIUM);
 }
 
@@ -109,7 +109,7 @@ static void
 test_writeverify16(void)
 {
         logging(LOG_VERBOSE, "Test WRITEVERIFY16 when medium is ejected.");
-        WRITEVERIFY16(sd, 0, block_size, block_size, 0, 0, 0, 0, scratch,
+        WRITEVERIFY16(sd, 0, block_size, block_size, 0, 0, 1, 0, scratch,
                       EXPECT_NO_MEDIUM);
 }
 

--- a/test-tool/test_readonly_sbc.c
+++ b/test-tool/test_readonly_sbc.c
@@ -82,7 +82,7 @@ static void
 test_writeverify10(void)
 {
         logging(LOG_VERBOSE, "Test WRITEVERIFY10 fails with WRITE_PROTECTED");
-        WRITEVERIFY10(sd, 0, block_size, block_size, 0, 0, 0, 0, scratch,
+        WRITEVERIFY10(sd, 0, block_size, block_size, 0, 0, 1, 0, scratch,
                       EXPECT_WRITE_PROTECTED);
 }
 
@@ -90,7 +90,7 @@ static void
 test_writeverify12(void)
 {
         logging(LOG_VERBOSE, "Test WRITEVERIFY12 fails with WRITE_PROTECTED");
-        WRITEVERIFY12(sd, 0, block_size, block_size, 0, 0, 0, 0, scratch,
+        WRITEVERIFY12(sd, 0, block_size, block_size, 0, 0, 1, 0, scratch,
                       EXPECT_WRITE_PROTECTED);
 }
 
@@ -98,7 +98,7 @@ static void
 test_writeverify16(void)
 {
         logging(LOG_VERBOSE, "Test WRITEVERIFY16 fails with WRITE_PROTECTED");
-        WRITEVERIFY16(sd, 0, block_size, block_size, 0, 0, 0, 0, scratch,
+        WRITEVERIFY16(sd, 0, block_size, block_size, 0, 0, 1, 0, scratch,
                       EXPECT_WRITE_PROTECTED);
 }
 

--- a/test-tool/test_writeverify10_beyond_eol.c
+++ b/test-tool/test_writeverify10_beyond_eol.c
@@ -46,7 +46,7 @@ test_writeverify10_beyond_eol(void)
                         break;
                 }
                 WRITEVERIFY10(sd, num_blocks + 1 - i,
-                              i * block_size, block_size, 0, 0, 0, 0, scratch,
+                              i * block_size, block_size, 0, 0, 1, 0, scratch,
                               EXPECT_LBA_OOB);
         }
 
@@ -56,7 +56,7 @@ test_writeverify10_beyond_eol(void)
                         break;
                 }
                 WRITEVERIFY10(sd, 0x80000000,
-                              i * block_size, block_size, 0, 0, 0, 0, scratch,
+                              i * block_size, block_size, 0, 0, 1, 0, scratch,
                               EXPECT_LBA_OOB);
         }
 
@@ -66,7 +66,7 @@ test_writeverify10_beyond_eol(void)
                         break;
                 }
                 WRITEVERIFY10(sd, -1, i * block_size,
-                              block_size, 0, 0, 0, 0, scratch,
+                              block_size, 0, 0, 1, 0, scratch,
                               EXPECT_LBA_OOB);
         }
 
@@ -76,7 +76,7 @@ test_writeverify10_beyond_eol(void)
                         break;
                 }
                 WRITEVERIFY10(sd, num_blocks - 1,
-                              i * block_size, block_size, 0, 0, 0, 0, scratch,
+                              i * block_size, block_size, 0, 0, 1, 0, scratch,
                               EXPECT_LBA_OOB);
         }
 }

--- a/test-tool/test_writeverify10_dpo.c
+++ b/test-tool/test_writeverify10_dpo.c
@@ -64,11 +64,11 @@ test_writeverify10_dpo(void)
         logging(LOG_VERBOSE, "Test WRITEVERIFY10 with DPO==1");
         if (dpofua) {
                 WRITEVERIFY10(sd, 0, block_size,
-                              block_size, 0, 1, 0, 0, scratch,
+                              block_size, 0, 1, 1, 0, scratch,
                               EXPECT_STATUS_GOOD);
         } else {
                 WRITEVERIFY10(sd, 0, block_size,
-                              block_size, 0, 1, 0, 0, scratch,
+                              block_size, 0, 1, 1, 0, scratch,
                               EXPECT_INVALID_FIELD_IN_CDB);
         }
 

--- a/test-tool/test_writeverify10_residuals.c
+++ b/test-tool/test_writeverify10_residuals.c
@@ -62,6 +62,7 @@ test_writeverify10_residuals(void)
 
         memset(task, 0, sizeof(struct scsi_task));
         task->cdb[0] = SCSI_OPCODE_WRITE_VERIFY10;
+        task->cdb[1] = 2; /* BYTCHK = 1 */
         task->cdb[8] = 1;
         task->cdb_size = 10;
         task->xfer_dir = SCSI_XFER_WRITE;
@@ -121,6 +122,7 @@ test_writeverify10_residuals(void)
 
         memset(task, 0, sizeof(struct scsi_task));
         task->cdb[0] = SCSI_OPCODE_WRITE_VERIFY10;
+        task->cdb[1] = 2; /* BYTCHK = 1 */
         task->cdb[8] = 1;
         task->cdb_size = 10;
         task->xfer_dir = SCSI_XFER_WRITE;
@@ -164,6 +166,7 @@ test_writeverify10_residuals(void)
 
         memset(task, 0, sizeof(struct scsi_task));
         task->cdb[0] = SCSI_OPCODE_WRITE_VERIFY10;
+        task->cdb[1] = 2; /* BYTCHK = 1 */
         task->cdb[8] = 1;
         task->cdb_size = 10;
         task->xfer_dir = SCSI_XFER_WRITE;
@@ -213,6 +216,7 @@ test_writeverify10_residuals(void)
 
         memset(task, 0, sizeof(struct scsi_task));
         task->cdb[0] = SCSI_OPCODE_WRITE_VERIFY10;
+        task->cdb[1] = 2; /* BYTCHK = 1 */
         task->cdb[8] = 2;
         task->cdb_size = 10;
         task->xfer_dir = SCSI_XFER_WRITE;
@@ -266,6 +270,7 @@ test_writeverify10_residuals(void)
 
         memset(task, 0, sizeof(struct scsi_task));
         task->cdb[0] = SCSI_OPCODE_WRITE_VERIFY10;
+        task->cdb[1] = 2; /* BYTCHK = 1 */
         task->cdb[8] = 1;
         task->cdb_size = 10;
         task->xfer_dir = SCSI_XFER_WRITE;
@@ -338,6 +343,7 @@ test_writeverify10_residuals(void)
 
         memset(task, 0, sizeof(struct scsi_task));
         task->cdb[0] = SCSI_OPCODE_WRITE_VERIFY10;
+        task->cdb[1] = 2; /* BYTCHK = 1 */
         task->cdb[8] = 2;
         task->cdb_size = 10;
         task->xfer_dir = SCSI_XFER_WRITE;

--- a/test-tool/test_writeverify10_simple.c
+++ b/test-tool/test_writeverify10_simple.c
@@ -42,7 +42,7 @@ test_writeverify10_simple(void)
                         break;
                 }
                 WRITEVERIFY10(sd, 0, i * block_size,
-                              block_size, 0, 0, 0, 0, scratch,
+                              block_size, 0, 0, 1, 0, scratch,
                               EXPECT_STATUS_GOOD);
         }
 
@@ -52,7 +52,7 @@ test_writeverify10_simple(void)
                         break;
                 }
                 WRITEVERIFY10(sd, num_blocks - i,
-                              i * block_size, block_size, 0, 0, 0, 0, scratch,
+                              i * block_size, block_size, 0, 0, 1, 0, scratch,
                               EXPECT_STATUS_GOOD);
         }
 }

--- a/test-tool/test_writeverify10_wrprotect.c
+++ b/test-tool/test_writeverify10_wrprotect.c
@@ -46,7 +46,7 @@ test_writeverify10_wrprotect(void)
                 logging(LOG_VERBOSE, "Device does not support/use protection information. All commands should fail.");
                 for (i = 1; i < 8; i++) {
                         WRITEVERIFY10(sd, 0, block_size, block_size,
-                                      i, 0, 0, 0, scratch,
+                                      i, 0, 1, 0, scratch,
                                       EXPECT_INVALID_FIELD_IN_CDB);
                 }
                 return;

--- a/test-tool/test_writeverify12_beyond_eol.c
+++ b/test-tool/test_writeverify12_beyond_eol.c
@@ -46,7 +46,7 @@ test_writeverify12_beyond_eol(void)
                         break;
                 }
                 WRITEVERIFY12(sd, num_blocks + 1 - i,
-                              i * block_size, block_size, 0, 0, 0, 0, scratch,
+                              i * block_size, block_size, 0, 0, 1, 0, scratch,
                               EXPECT_LBA_OOB);
         }
 
@@ -56,7 +56,7 @@ test_writeverify12_beyond_eol(void)
                         break;
                 }
                 WRITEVERIFY12(sd, 0x80000000,
-                              i * block_size, block_size, 0, 0, 0, 0, scratch,
+                              i * block_size, block_size, 0, 0, 1, 0, scratch,
                               EXPECT_LBA_OOB);
         }
 
@@ -66,7 +66,7 @@ test_writeverify12_beyond_eol(void)
                         break;
                 }
                 WRITEVERIFY12(sd, -1, i * block_size,
-                              block_size, 0, 0, 0, 0, scratch,
+                              block_size, 0, 0, 1, 0, scratch,
                               EXPECT_LBA_OOB);
         }
 
@@ -76,7 +76,7 @@ test_writeverify12_beyond_eol(void)
                         break;
                 }
                 WRITEVERIFY12(sd, num_blocks - 1,
-                              i * block_size, block_size, 0, 0, 0, 0, scratch,
+                              i * block_size, block_size, 0, 0, 1, 0, scratch,
                               EXPECT_LBA_OOB);
         }
 }

--- a/test-tool/test_writeverify12_dpo.c
+++ b/test-tool/test_writeverify12_dpo.c
@@ -64,11 +64,11 @@ test_writeverify12_dpo(void)
         logging(LOG_VERBOSE, "Test WRITEVERIFY12 with DPO==1");
         if (dpofua) {
                 WRITEVERIFY12(sd, 0, block_size,
-                              block_size, 0, 1, 0, 0, scratch,
+                              block_size, 0, 1, 1, 0, scratch,
                               EXPECT_STATUS_GOOD);
         } else {
                 WRITEVERIFY12(sd, 0, block_size,
-                              block_size, 0, 1, 0, 0, scratch,
+                              block_size, 0, 1, 1, 0, scratch,
                               EXPECT_INVALID_FIELD_IN_CDB);
         }
 

--- a/test-tool/test_writeverify12_simple.c
+++ b/test-tool/test_writeverify12_simple.c
@@ -42,7 +42,7 @@ test_writeverify12_simple(void)
                         break;
                 }
                 WRITEVERIFY12(sd, 0, i * block_size,
-                              block_size, 0, 0, 0, 0, scratch,
+                              block_size, 0, 0, 1, 0, scratch,
                               EXPECT_STATUS_GOOD);
         }
 
@@ -52,7 +52,7 @@ test_writeverify12_simple(void)
                         break;
                 }
                 WRITEVERIFY12(sd, num_blocks - i,
-                              i * block_size, block_size, 0, 0, 0, 0, scratch,
+                              i * block_size, block_size, 0, 0, 1, 0, scratch,
                               EXPECT_STATUS_GOOD);
         }
 }

--- a/test-tool/test_writeverify12_wrprotect.c
+++ b/test-tool/test_writeverify12_wrprotect.c
@@ -46,7 +46,7 @@ test_writeverify12_wrprotect(void)
                 logging(LOG_VERBOSE, "Device does not support/use protection information. All commands should fail.");
                 for (i = 1; i < 8; i++) {
                         WRITEVERIFY12(sd, 0, block_size, block_size,
-                                      i, 0, 0, 0, scratch,
+                                      i, 0, 1, 0, scratch,
                                       EXPECT_INVALID_FIELD_IN_CDB);
                 }
                 return;

--- a/test-tool/test_writeverify16_beyond_eol.c
+++ b/test-tool/test_writeverify16_beyond_eol.c
@@ -42,7 +42,7 @@ test_writeverify16_beyond_eol(void)
                         break;
                 }
                 WRITEVERIFY16(sd, num_blocks + 1 - i,
-                              i * block_size, block_size, 0, 0, 0, 0, scratch,
+                              i * block_size, block_size, 0, 0, 1, 0, scratch,
                               EXPECT_LBA_OOB);
         }
 
@@ -52,7 +52,7 @@ test_writeverify16_beyond_eol(void)
                         break;
                 }
                 WRITEVERIFY16(sd, 0x8000000000000000ULL,
-                              i * block_size, block_size, 0, 0, 0, 0, scratch,
+                              i * block_size, block_size, 0, 0, 1, 0, scratch,
                               EXPECT_LBA_OOB);
         }
 
@@ -62,7 +62,7 @@ test_writeverify16_beyond_eol(void)
                         break;
                 }
                 WRITEVERIFY16(sd, -1,
-                              i * block_size, block_size, 0, 0, 0, 0, scratch,
+                              i * block_size, block_size, 0, 0, 1, 0, scratch,
                               EXPECT_LBA_OOB);
         }
 
@@ -72,7 +72,7 @@ test_writeverify16_beyond_eol(void)
                         break;
                 }
                 WRITEVERIFY16(sd, num_blocks - 1,
-                              i * block_size, block_size, 0, 0, 0, 0, scratch,
+                              i * block_size, block_size, 0, 0, 1, 0, scratch,
                               EXPECT_LBA_OOB);
         }
 }

--- a/test-tool/test_writeverify16_dpo.c
+++ b/test-tool/test_writeverify16_dpo.c
@@ -65,11 +65,11 @@ test_writeverify16_dpo(void)
         memset(scratch, 0xa6, block_size);
         if (dpofua) {
                 WRITEVERIFY16(sd, 0, block_size,
-                              block_size, 0, 1, 0, 0, scratch,
+                              block_size, 0, 1, 1, 0, scratch,
                               EXPECT_STATUS_GOOD);
         } else {
                 WRITEVERIFY16(sd, 0, block_size,
-                              block_size, 0, 1, 0, 0, scratch,
+                              block_size, 0, 1, 1, 0, scratch,
                               EXPECT_INVALID_FIELD_IN_CDB);
         }
 

--- a/test-tool/test_writeverify16_residuals.c
+++ b/test-tool/test_writeverify16_residuals.c
@@ -53,7 +53,7 @@ test_writeverify16_residuals(void)
         }
 
         /* check if writeverify16 is supported */
-        WRITEVERIFY16(sd, 0, 0, block_size, 0, 0, 0, 0, NULL,
+        WRITEVERIFY16(sd, 0, 0, block_size, 0, 0, 1, 0, NULL,
                       EXPECT_STATUS_GOOD);
 
         if (sd->iscsi_ctx == NULL) {

--- a/test-tool/test_writeverify16_simple.c
+++ b/test-tool/test_writeverify16_simple.c
@@ -43,7 +43,7 @@ test_writeverify16_simple(void)
                         break;
                 }
                 WRITEVERIFY16(sd, 0, i * block_size,
-                              block_size, 0, 0, 0, 0, scratch,
+                              block_size, 0, 0, 1, 0, scratch,
                               EXPECT_STATUS_GOOD);
         }
 
@@ -53,7 +53,7 @@ test_writeverify16_simple(void)
                         break;
                 }
                 WRITEVERIFY16(sd, num_blocks - i,
-                              i * block_size, block_size, 0, 0, 0, 0, scratch,
+                              i * block_size, block_size, 0, 0, 1, 0, scratch,
                               EXPECT_STATUS_GOOD);
         }
 }


### PR DESCRIPTION
From SBC-4: BYTCHK = 0 means that the Data-Out buffer contents
must not be used. BYTCHK = 1 means that the Data-Out buffer must
be compared against the data on the storage medium. Hence set
BYTCHK to 1 if EDTL != 0.

Signed-off-by: Bart Van Assche <bart.vanassche@sandisk.com>