### PR TITLE
PDU cancellation fixes for sync connect calls

### DIFF
--- a/include/iscsi-private.h
+++ b/include/iscsi-private.h
@@ -284,6 +284,7 @@ void iscsi_pdu_set_itt(struct iscsi_pdu *pdu, uint32_t itt);
 void iscsi_pdu_set_ritt(struct iscsi_pdu *pdu, uint32_t ritt);
 void iscsi_pdu_set_datasn(struct iscsi_pdu *pdu, uint32_t datasn);
 void iscsi_pdu_set_bufferoffset(struct iscsi_pdu *pdu, uint32_t bufferoffset);
+void iscsi_cancel_pdus(struct iscsi_context *iscsi);
 int iscsi_pdu_add_data(struct iscsi_context *iscsi, struct iscsi_pdu *pdu,
 		       unsigned char *dptr, int dsize);
 int iscsi_queue_pdu(struct iscsi_context *iscsi, struct iscsi_pdu *pdu);

--- a/lib/iscsi-command.c
+++ b/lib/iscsi-command.c
@@ -2697,22 +2697,5 @@ iscsi_scsi_cancel_task(struct iscsi_context *iscsi,
 void
 iscsi_scsi_cancel_all_tasks(struct iscsi_context *iscsi)
 {
-	struct iscsi_pdu *pdu;
-
-	while ((pdu = iscsi->waitpdu)) {
-		ISCSI_LIST_REMOVE(&iscsi->waitpdu, pdu);
-		if (pdu->callback) {
-			pdu->callback(iscsi, SCSI_STATUS_CANCELLED, NULL,
-				      pdu->private_data);
-		}
-		iscsi->drv->free_pdu(iscsi, pdu);
-	}
-	while ((pdu = iscsi->outqueue)) {
-		ISCSI_LIST_REMOVE(&iscsi->outqueue, pdu);
-		if (pdu->callback) {
-			pdu->callback(iscsi, SCSI_STATUS_CANCELLED, NULL,
-				      pdu->private_data);
-		}
-		iscsi->drv->free_pdu(iscsi, pdu);
-	}
+	iscsi_cancel_pdus(iscsi);
 }

--- a/lib/pdu.c
+++ b/lib/pdu.c
@@ -168,7 +168,6 @@ iscsi_tcp_free_pdu(struct iscsi_context *iscsi, struct iscsi_pdu *pdu)
 	iscsi_sfree(iscsi, pdu);
 }
 
-
 int
 iscsi_add_data(struct iscsi_context *iscsi, struct iscsi_data *data,
 	       unsigned char *dptr, int dsize, int pdualignment)
@@ -252,7 +251,6 @@ iscsi_get_pdu_data_size(const unsigned char *hdr)
 	return size;
 }
 
-
 int
 iscsi_get_pdu_padding_size(const unsigned char *hdr)
 {
@@ -332,7 +330,6 @@ int iscsi_process_target_nop_in(struct iscsi_context *iscsi,
 	return 0;
 }
 
-
 static void iscsi_reconnect_after_logout(struct iscsi_context *iscsi, int status,
                         void *command_data _U_, void *opaque _U_)
 {
@@ -391,7 +388,6 @@ int iscsi_process_reject(struct iscsi_context *iscsi,
 	iscsi->drv->free_pdu(iscsi, pdu);
 	return 0;
 }
-
 
 static void iscsi_process_pdu_serials(struct iscsi_context *iscsi, struct iscsi_in_pdu *in)
 {

--- a/lib/pdu.c
+++ b/lib/pdu.c
@@ -766,5 +766,5 @@ iscsi_timeout_scan(struct iscsi_context *iscsi)
 int
 iscsi_queue_pdu(struct iscsi_context *iscsi, struct iscsi_pdu *pdu)
 {
-        return iscsi->drv->queue_pdu(iscsi, pdu);
+	return iscsi->drv->queue_pdu(iscsi, pdu);
 }

--- a/lib/sync.c
+++ b/lib/sync.c
@@ -114,6 +114,11 @@ iscsi_connect_sync(struct iscsi_context *iscsi, const char *portal)
 	/* clear connect_data so it doesnt point to our stack */
 	iscsi->connect_data = NULL;
 
+	/* in case of error, cancel any pending pdus */
+	if (state.status != SCSI_STATUS_GOOD) {
+		iscsi_cancel_pdus(iscsi);
+	}
+
 	return (state.status == SCSI_STATUS_GOOD) ? 0 : -1;
 }
 
@@ -135,9 +140,9 @@ iscsi_full_connect_sync(struct iscsi_context *iscsi,
 
 	event_loop(iscsi, &state);
 
-	/* in case of error, clear loggedin flag to prevent pending pdu callbacks */
-	if (state.status != 0) {
-		iscsi->is_loggedin = 0;
+	/* in case of error, cancel any pending pdus */
+	if (state.status != SCSI_STATUS_GOOD) {
+		iscsi_cancel_pdus(iscsi);
 	}
 
 	return (state.status == SCSI_STATUS_GOOD) ? 0 : -1;

--- a/lib/sync.c
+++ b/lib/sync.c
@@ -135,6 +135,11 @@ iscsi_full_connect_sync(struct iscsi_context *iscsi,
 
 	event_loop(iscsi, &state);
 
+	/* in case of error, clear loggedin flag to prevent pending pdu callbacks */
+	if (state.status != 0) {
+		iscsi->is_loggedin = 0;
+	}
+
 	return (state.status == SCSI_STATUS_GOOD) ? 0 : -1;
 }
 


### PR DESCRIPTION
These address a segfault which may happen if the event_poll() return early (eg. timeout) for sync connect calls. On those cases, it is possible for a context to have PDUs queued which point to a local stack which have returned.