### PR TITLE
Make iscsi_set_noautoreconnect public

### DIFF
--- a/include/iscsi-private.h
+++ b/include/iscsi-private.h
@@ -350,8 +350,6 @@ uint32_t crc32c(uint8_t *buf, int len);
 
 struct scsi_task *iscsi_scsi_get_task_from_pdu(struct iscsi_pdu *pdu);
 
-void iscsi_set_noautoreconnect(struct iscsi_context *iscsi, int state);
-
 void iscsi_decrement_iface_rr(void);
 
 #define ISCSI_LOG(iscsi, level, format, ...) \

--- a/include/iscsi.h
+++ b/include/iscsi.h
@@ -1595,6 +1595,16 @@ iscsi_set_tcp_syncnt(struct iscsi_context *iscsi, int value);
 EXTERN void
 iscsi_set_bind_interfaces(struct iscsi_context *iscsi, char * interfaces);
 
+/*
+ * This function is to disable auto reconnect logic.
+ *
+ *  0 - Disable this feature (auto reconnect)
+ *  1 - Enable this feature (no auto reconnect)
+ */
+EXTERN void
+iscsi_set_noautoreconnect(struct iscsi_context *iscsi, int state);
+
+
 /* This function is to set if we should retry a failed reconnect
    
    count is defined as follows:


### PR DESCRIPTION
In our use of libiscsi at Datto, we have come across several issues related to the automatic reconnect logic (mainly its interaction with `POLLHUP`). This allows us to disable the functionality, at the expense of writing our own reconnect logic.

Related: #241