### PR TITLE
test_writesame_unmap_until_end: fix unsupported fallback

### DIFF
--- a/test-tool/test_writesame10_unmap_until_end.c
+++ b/test-tool/test_writesame10_unmap_until_end.c
@@ -39,8 +39,8 @@ test_writesame10_unmap_until_end(void)
         if (inq_bl->wsnz) {
                 logging(LOG_NORMAL, "WRITESAME10 does not support 0-blocks."
                         "WSNZ == 1");
-                WRITESAME10(sd, 0,
-                            0, 1, 0, 1, 0, 0, scratch,
+                memset(scratch, 0, block_size);
+                WRITESAME10(sd, 0, block_size, 0, 0, 1, 0, 0, scratch,
                             EXPECT_INVALID_FIELD_IN_CDB);
                 return;
         }

--- a/test-tool/test_writesame16_unmap_until_end.c
+++ b/test-tool/test_writesame16_unmap_until_end.c
@@ -40,8 +40,8 @@ test_writesame16_unmap_until_end(void)
         if (inq_bl->wsnz) {
                 logging(LOG_NORMAL, "WRITESAME16 does not support 0-blocks."
                         "WSNZ == 1");
-                WRITESAME16(sd, 0,
-                            0, 1, 0, 1, 0, 0, scratch,
+                memset(scratch, 0, block_size);
+                WRITESAME16(sd, 0, block_size, 0, 0, 1, 0, 0, scratch,
                             EXPECT_INVALID_FIELD_IN_CDB);
                 return;
         }
@@ -55,7 +55,7 @@ test_writesame16_unmap_until_end(void)
                 WRITE16(sd, num_blocks - i,
                         i * block_size, block_size, 0, 0, 0, 0, 0, scratch,
                         EXPECT_STATUS_GOOD);
-                
+
                 logging(LOG_VERBOSE, "Unmap %d blocks using WRITESAME16", i);
                 memset(scratch, 0, block_size);
                 WRITESAME16(sd, num_blocks - i,


### PR DESCRIPTION
2e947cc1de78d681c95c8be617724e26679a1dae added logic to check that
targets missing zero block writesame support return INVALID_FIELD_IN_CDB
to such requests. However, this change incorrectly set the writesame
number_of_logical_blocks field to one.

Signed-off-by: David Disseldorp <ddiss@suse.de>