### PR TITLE
iser: Use local container_of definition

### DIFF
--- a/lib/iser.c
+++ b/lib/iser.c
@@ -32,6 +32,20 @@
 #include <semaphore.h>
 #include <poll.h>
 
+
+#ifndef container_of
+/**
+  * container_of - cast a member of a structure out to the containing structure
+  * @ptr:        the pointer to the member.
+  * @type:       the type of the container struct this is embedded in.
+  * @member:     the name of the member within the struct.
+  *
+ */
+#define container_of(ptr, type, member) \
+    ((type *) ((uint8_t *)(ptr) - offsetof(type, member)))
+#endif
+
+
 #ifdef __linux
 
 /* MUST keep in sync with socket.c */


### PR DESCRIPTION
The code was implicitly dependent on container_of from
inifiniband/verbs.h, however that's been removed in rdma-core
latest release:

https://github.com/linux-rdma/rdma-core/commit/ce0274acffc78ed2861a56bdc34cdd3d60c20e1f

Define container_of locally if it's not already defined