### PR TITLE
Fix the 0 blocks writesame failed when target claims supporting maxim…

### DIFF
--- a/test-tool/test_writesame10_0blocks.c
+++ b/test-tool/test_writesame10_0blocks.c
@@ -53,7 +53,7 @@ test_writesame10_0blocks(void)
                 return;
         }
 
-        if (inq_bl->max_ws_len > 0 && num_blocks >= inq_bl->max_ws_len) {
+        if (inq_bl->max_ws_len > 0 && num_blocks > inq_bl->max_ws_len) {
             WRITESAME10(sd, 0, block_size, 0, 0, 0, 0, 0, scratch,
                         EXPECT_INVALID_FIELD_IN_CDB);
         } else {

--- a/test-tool/test_writesame16_0blocks.c
+++ b/test-tool/test_writesame16_0blocks.c
@@ -48,7 +48,7 @@ test_writesame16_0blocks(void)
         }
 
 
-        if (inq_bl->max_ws_len > 0 && num_blocks >= inq_bl->max_ws_len) {
+        if (inq_bl->max_ws_len > 0 && num_blocks > inq_bl->max_ws_len) {
             WRITESAME16(sd, 0, block_size, 0, 0, 0, 0, 0, scratch,
                         EXPECT_INVALID_FIELD_IN_CDB);
         } else {


### PR DESCRIPTION
…um writesame length to LUN's total blocks number.

When target claim it support maximum writesame length to the total blocks number, when
we trigger 0blocks writesame opertion, we should expect it to be succeed instread of failure.

Testing Done:
1. Ensure target return max writesame length to the number of blocks at querying block limits.
2. Without the fix, test cases failed with
```
    Test: ZeroBlocks ...    [FAILED] WRITESAME10 successful but should have failed with ILLEGAL_REQUEST(0x05)/INVALID_FIELD_IN_CDB(0x2400)
FAILED
    1. test_writesame10_0blocks.c:58  - CU_ASSERT_EQUAL(_r,0)
<snipped>
    Test: ZeroBlocks ...    [FAILED] WRITESAME16 successful but should have failed with ILLEGAL_REQUEST(0x05)/INVALID_FIELD_IN_CDB(0x2400)
FAILED
    1. test_writesame16_0blocks.c:53  - CU_ASSERT_EQUAL(_r,0)
```
Witht the fix, the 0blocks writesame test cases succeed.
```
Suite: WriteSame10
  Test: Simple ...passed
  Test: BeyondEol ...passed
  Test: ZeroBlocks ... passed
<snipped>
Suite: WriteSame16
  Test: Simple ...passed
  Test: BeyondEol ...passed
  Test: ZeroBlocks ...passed
```