### PR TITLE
Fix warnings from Coverity and GCC 8

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -29,6 +29,7 @@ AC_ARG_ENABLE([werror], [AS_HELP_STRING([--disable-werror],
 
 if test "$ac_cv_prog_gcc" = yes; then
    WARN_CFLAGS="-Wall -W -Wshadow -Wstrict-prototypes -Wpointer-arith -Wcast-align -Wno-strict-aliasing"
+   WARN_CFLAGS="$WARN_CFLAGS -Wno-unknown-warning-option -Wno-stringop-truncation"
    if test "x$enable_werror" != "xno"; then
        WARN_CFLAGS="$WARN_CFLAGS -Werror"
    fi

--- a/lib/logging.c
+++ b/lib/logging.c
@@ -73,9 +73,9 @@ iscsi_log_message(struct iscsi_context *iscsi, int level, const char *format, ..
 	}
 
 	if (iscsi->target_name[0]) {
-		static char message2[1024];
+		static char message2[1282];
 
-		snprintf(message2, 1024, "%s [%s]", message, iscsi->target_name);
+		snprintf(message2, 1282, "%s [%s]", message, iscsi->target_name);
 		iscsi->log_fn(level, message2);
 	}
 	else

--- a/lib/scsi-lowlevel.c
+++ b/lib/scsi-lowlevel.c
@@ -1086,6 +1086,7 @@ scsi_maintenancein_datain_getfullsize(struct scsi_task *task)
 				(task_get_uint8(task, 1) & 0x80) ? 12 : 0 +
 				task_get_uint16(task, 2);
 		}
+		return -1;
 	default:
 		return -1;
 	}

--- a/lib/sync.c
+++ b/lib/sync.c
@@ -88,10 +88,8 @@ iscsi_sync_cb(struct iscsi_context *iscsi _U_, int status,
 {
 	struct iscsi_sync_state *state = private_data;
 
-	if (state != NULL) {
-		state->status    = status;
-		state->finished = 1;
-	}
+	state->status    = status;
+	state->finished = 1;
 }
 
 int
@@ -1871,11 +1869,9 @@ iscsi_discovery_cb(struct iscsi_context *iscsi _U_, int status,
                 }
         }
 
-	if (state != NULL) {
-		state->status    = status;
-		state->finished = 1;
-                state->ptr = dahead;
-	}
+	state->status    = status;
+	state->finished = 1;
+	state->ptr = dahead;
 }
 
 struct iscsi_discovery_address *


### PR DESCRIPTION
This fixes various memory leaks reported by Coverity, as well as new warnings in GCC 8 (sometimes by disabling them...).