### PR TITLE
buildsys: add options to disable part of the build, fix cunit detection

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,10 +1,13 @@
 # Generic definitions
-SUBDIRS = lib doc utils examples
+SUBDIRS = lib doc utils
 if BUILD_TEST_TOOL
 SUBDIRS += test-tool
 endif
 if BUILD_TESTS
 SUBDIRS += tests
+endif
+if BUILD_EXAMPLES
+SUBDIRS += examples
 endif
 
 ACLOCAL_AMFLAGS =-I m4

--- a/Makefile.am
+++ b/Makefile.am
@@ -1,5 +1,8 @@
 # Generic definitions
-SUBDIRS = lib doc utils test-tool examples
+SUBDIRS = lib doc utils examples
+if BUILD_TEST_TOOL
+SUBDIRS += test-tool
+endif
 if BUILD_TESTS
 SUBDIRS += tests
 endif

--- a/Makefile.am
+++ b/Makefile.am
@@ -1,5 +1,8 @@
 # Generic definitions
-SUBDIRS = lib doc utils test-tool tests examples
+SUBDIRS = lib doc utils test-tool examples
+if BUILD_TESTS
+SUBDIRS += tests
+endif
 
 ACLOCAL_AMFLAGS =-I m4
 AUTOMAKE_OPTIONS = foreign subdir-objects

--- a/configure.ac
+++ b/configure.ac
@@ -63,6 +63,14 @@ AC_ARG_ENABLE([tests],
 AM_CONDITIONAL([BUILD_TESTS],
                [expr "$ENABLE_TESTS" : yes > /dev/null 2>&1])
 
+AC_ARG_ENABLE([examples],
+              [AC_HELP_STRING([--enable-examples],
+                              [Enable building examples])],
+              [ENABLE_EXAMPLES=$enableval],
+              [ENABLE_EXAMPLES=yes])
+AM_CONDITIONAL([BUILD_EXAMPLES],
+               [expr "$ENABLE_EXAMPLES" : yes > /dev/null 2>&1])
+
 AC_CONFIG_HEADER(config.h)
 
 AC_CHECK_LIB([gcrypt], [gcry_control])

--- a/configure.ac
+++ b/configure.ac
@@ -128,20 +128,18 @@ if test x"$libiscsi_cv_HAVE_LINUX_ISER" = x"yes"; then
 fi
 AM_CONDITIONAL([HAVE_LINUX_ISER], [test $libiscsi_cv_HAVE_LINUX_ISER = yes])
 
-AC_MSG_CHECKING(whether libcunit is available)
-ac_save_CFLAGS="$CFLAGS"
-ac_save_LIBS="$LIBS"
-CFLAGS="$CFLAGS $GLIB_CFLAGS"
-LIBS="$GLIB_LIBS $LIBS -lcunit"
-AC_TRY_LINK([
-#include <CUnit/CUnit.h>
-], [], [ac_cv_have_cunit=yes], [ac_cv_have_cunit=no])
-CFLAGS="$ac_save_CFLAGS"
-LIBS="$ac_save_LIBS"
-if test "$ac_cv_have_cunit" = yes ; then
-  AC_MSG_RESULT(yes)
-else
-  AC_MSG_RESULT(no)
+AC_CACHE_CHECK([whether libcunit is available],
+               [ac_cv_have_cunit],
+               [ac_save_CFLAGS="$CFLAGS"
+                ac_save_LIBS="$LIBS"
+                CFLAGS="$CFLAGS $GLIB_CFLAGS"
+                LIBS="$GLIB_LIBS $LIBS -lcunit"
+                AC_TRY_LINK([
+                    #include <CUnit/CUnit.h>
+                    ], [], [ac_cv_have_cunit=yes], [ac_cv_have_cunit=no])
+                CFLAGS="$ac_save_CFLAGS"
+                LIBS="$ac_save_LIBS"])
+if ! test "$ac_cv_have_cunit" = yes ; then
   AC_MSG_NOTICE(You need libcunit to build the test suite.)
   AC_MSG_NOTICE(The scsi/iscsi test suite will not be built.)
 fi

--- a/configure.ac
+++ b/configure.ac
@@ -47,6 +47,14 @@ AC_ARG_ENABLE([manpages],
 AM_CONDITIONAL(BUILD_MANPAGES,
                [expr "$ENABLE_MANPAGES" : yes > /dev/null 2>&1])
 
+AC_ARG_ENABLE([test_tool],
+              [AC_HELP_STRING([--enable-test-tool],
+                              [Enable building test-tool (to test a remote server)])],
+              [ENABLE_TEST_TOOL=$enableval],
+              [ENABLE_TEST_TOOL=yes])
+AM_CONDITIONAL([BUILD_TEST_TOOL],
+               [expr "$ENABLE_TEST_TOOL" : yes > /dev/null 2>&1])
+
 AC_ARG_ENABLE([tests],
               [AC_HELP_STRING([--enable-tests],
                               [Enable building tests])],

--- a/configure.ac
+++ b/configure.ac
@@ -47,6 +47,14 @@ AC_ARG_ENABLE([manpages],
 AM_CONDITIONAL(BUILD_MANPAGES,
                [expr "$ENABLE_MANPAGES" : yes > /dev/null 2>&1])
 
+AC_ARG_ENABLE([tests],
+              [AC_HELP_STRING([--enable-tests],
+                              [Enable building tests])],
+              [ENABLE_TESTS=$enableval],
+              [ENABLE_TESTS=yes])
+AM_CONDITIONAL([BUILD_TESTS],
+               [expr "$ENABLE_TESTS" : yes > /dev/null 2>&1])
+
 AC_CONFIG_HEADER(config.h)
 
 AC_CHECK_LIB([gcrypt], [gcry_control])


### PR DESCRIPTION
In some cases, tests, tool and eexamples are not needed, especially
in a production system, when everything has been pre-validated.

Add three new config options, each to disable parts of the build:
  - tests
  - test-tool
  - examples

Additionally, make the cunit detection really a cache-val, using the 
canonical autoconf machinery.