### PR TITLE
test-tool: fix MPIO clear_pr() behaviour

### DIFF
--- a/test-tool/iscsi-test-cu.c
+++ b/test-tool/iscsi-test-cu.c
@@ -1245,11 +1245,12 @@ main(int argc, char *argv[])
                                 "Failed to connect to SCSI device %d\n", i);
                         goto err_sds_free;
                 }
-                if (clear_pr(mp_sds[i]) < 0) {
-                        printf("One or more persistent reservations keys have been registered\n");
-                        return -1;
-                }
         }
+
+	if (clear_pr(sd) < 0) {
+		printf("One or more persistent reservations keys have been registered\n");
+		goto err_sds_free;
+	}
 
         if (mp_num_sds > 1) {
                 /* check that all multipath sds identify as the same LU */


### PR DESCRIPTION
clear_pr() can be called before connect_scsi_device() has been invoked
on each MPIO sdev. This results in a NULL pointer dereference in the
send_scsi_command() MPIO NOP-responder code-path.

Fix this by invoking clear_pr() after the MPIO connect_scsi_device()
loop has run. clear_pr() also only needs to be invoked via a single
path, so do so via the first path only.

Link: https://github.com/sahlberg/libiscsi/issues/289
Fixes: 16435a9 ("iscsi-test-cu: Improve persistent reservation clearing")
Signed-off-by: David Disseldorp <ddiss@suse.de>