### PR TITLE
Added support for iSER related iSCSI keys

### DIFF
--- a/lib/iser.c
+++ b/lib/iser.c
@@ -1422,6 +1422,9 @@ void iscsi_init_iser_transport(struct iscsi_context *iscsi)
 	iscsi->drv = &iscsi_transport_iser;
 	iscsi->opaque = iscsi_malloc(iscsi, sizeof(struct iser_conn));
 	iscsi->transport = ISER_TRANSPORT;
+	/* Update iSCSI params as per iSER transport */
+	iscsi->initiator_max_recv_data_segment_length = ISCSI_DEF_MAX_RECV_SEG_LEN;
+	iscsi->target_max_recv_data_segment_length = ISCSI_DEF_MAX_RECV_SEG_LEN;
 }
 
 #endif


### PR DESCRIPTION
Added support for negotiating below keys:
RDMAExtensions, TargetRecvDataSegmentLength, and
InitiatorRecvDataSegmentLength.

These are required to support iSER. See RFC5046 Section 6.