### PR TITLE
lib/iser.c: fix overflow_data_size NULL ptr dereference

### DIFF
--- a/lib/iser.c
+++ b/lib/iser.c
@@ -624,6 +624,9 @@ overflow_data_size(struct iser_pdu *iser_pdu)
 {
 	int data_size;
 
+    if (!iser_pdu->iscsi_pdu.scsi_cbdata.task) {
+        return 0;
+    }
 	data_size = iser_pdu->iscsi_pdu.scsi_cbdata.task->expxferlen;
 
 	return (data_size > DATA_BUFFER_SIZE);


### PR DESCRIPTION
Discovered this while running iSCSI.iSCSITMF AbortTaskSimpleAsync
test case. For Task Management command iser_pdu->iscsi_pdu.scsi_cbdata
is not set. When test case tries to send Task Management command
via common API iser_send_command() - it calls overflow_data_size
which tries to dereference scsi_cbdata leading to SEGFAULT.

Added a non-NULL check for scsi_cbdata before accessing it.

Link: https://github.com/sahlberg/libiscsi/issues/293