### PR TITLE
discovery: permit SendTargets on normal sessions

### DIFF
--- a/lib/discovery.c
+++ b/lib/discovery.c
@@ -39,12 +39,6 @@ iscsi_discovery_async(struct iscsi_context *iscsi, iscsi_command_cb cb,
 	struct iscsi_pdu *pdu;
 	char *str;
 
-	if (iscsi->session_type != ISCSI_SESSION_DISCOVERY) {
-		iscsi_set_error(iscsi, "Trying to do discovery on "
-				"non-discovery session.");
-		return -1;
-	}
-
 	pdu = iscsi_allocate_pdu(iscsi, ISCSI_PDU_TEXT_REQUEST,
 				 ISCSI_PDU_TEXT_RESPONSE,
 				 iscsi_itt_post_increment(iscsi),


### PR DESCRIPTION
rfc3720 indicates that SendTargets on discovery *and* normal operational
sessions must be supported by targets:
   A system that contains targets MUST support discovery sessions on
   each of its iSCSI IP address-port pairs, and MUST support the
   SendTargets command on the discovery session.
   ...
   A target MUST support the SendTargets command on operational
   sessions...

Signed-off-by: David Disseldorp <ddiss@suse.de>