### PR TITLE
test-tool: rework iscsi_queue_pdu() overloading

### DIFF
--- a/test-tool/iscsi-support.c
+++ b/test-tool/iscsi-support.c
@@ -119,8 +119,6 @@ int readonly;
 int sbc3_support;
 int maximum_transfer_length;
 
-int (*real_iscsi_queue_pdu)(struct iscsi_context *iscsi, struct iscsi_pdu *pdu);
-
 static const unsigned char zeroBlock[4096];
 
 /**
@@ -567,15 +565,6 @@ wait_until_test_finished(struct iscsi_context *iscsi, struct iscsi_async_state *
                         break;
                 }
         }
-}
-
-int
-iscsi_queue_pdu(struct iscsi_context *iscsi, struct iscsi_pdu *pdu)
-{
-        if (local_iscsi_queue_pdu != NULL) {
-                local_iscsi_queue_pdu(iscsi, pdu);
-        }
-        return real_iscsi_queue_pdu(iscsi, pdu);
 }
 
 int

--- a/test-tool/iscsi-support.h
+++ b/test-tool/iscsi-support.h
@@ -782,7 +782,6 @@ struct iscsi_async_state {
 void wait_until_test_finished(struct iscsi_context *iscsi, struct iscsi_async_state *test_state);
 
 struct iscsi_pdu;
-int (*local_iscsi_queue_pdu)(struct iscsi_context *iscsi, struct iscsi_pdu *pdu);
 
 struct scsi_command_descriptor *get_command_descriptor(int opcode, int sa);
 

--- a/test-tool/iscsi-test-cu.c
+++ b/test-tool/iscsi-test-cu.c
@@ -59,12 +59,6 @@ int loglevel = LOG_NORMAL;
 struct scsi_device *sd = NULL;        /* mp_sds[0] alias */
 static unsigned int maxsectors;
 
-/*
- * this allows us to redefine how PDU are queued, at times, for
- * testing purposes
- */
-int (*real_iscsi_queue_pdu)(struct iscsi_context *iscsi, struct iscsi_pdu *pdu);
-
 /*****************************************************************
  *
  * list of tests and test suites
@@ -805,7 +799,6 @@ test_setup(void)
 {
         task = NULL;
         read_write_buf = NULL;
-        local_iscsi_queue_pdu = NULL;
 }
 
 void
@@ -1213,14 +1206,6 @@ main(int argc, char *argv[])
                 }
                 mp_num_sds++;
         }
-
-        /* So that we can override iscsi_queue_pdu in tests
-         * and replace or mutate the blob that we are about to write to the
-         * wire.
-         * This allows such tests to do their mutates and then call out
-         * to the real queueing function once they have modified the data.
-         */
-        real_iscsi_queue_pdu = dlsym(RTLD_NEXT, "iscsi_queue_pdu");
 
         if ((mp_num_sds == 0) || (mp_sds[0]->iscsi_url == NULL
                                         && mp_sds[0]->sgio_dev == NULL)) {

--- a/test-tool/test_compareandwrite_invalid_dataout_size.c
+++ b/test-tool/test_compareandwrite_invalid_dataout_size.c
@@ -53,6 +53,13 @@ test_compareandwrite_invalid_dataout_size(void)
         CHECK_FOR_THIN_PROVISIONING;
         CHECK_FOR_LBPPB_GT_1;
         CHECK_FOR_SBC;
+        if (sd->iscsi_ctx == NULL) {
+                const char *err = "[SKIPPED] This test is "
+                        "only supported for iSCSI backends";
+                logging(LOG_NORMAL, "%s", err);
+                CU_PASS(err);
+                return;
+        }
 
         local_iscsi_queue_pdu = my_iscsi_queue_pdu;
         

--- a/test-tool/test_compareandwrite_invalid_dataout_size.c
+++ b/test-tool/test_compareandwrite_invalid_dataout_size.c
@@ -27,11 +27,12 @@
 
 
 static int new_tl;
+static struct iscsi_transport iscsi_drv_orig;
 
-static int my_iscsi_queue_pdu(struct iscsi_context *iscsi _U_, struct iscsi_pdu *pdu _U_)
+static int my_iscsi_queue_pdu(struct iscsi_context *iscsi, struct iscsi_pdu *pdu)
 {
         if (pdu->outdata.data[0] != ISCSI_PDU_SCSI_REQUEST) {
-                return 0;
+                goto out;
         }
         switch (new_tl) {
         case 1:
@@ -43,7 +44,8 @@ static int my_iscsi_queue_pdu(struct iscsi_context *iscsi _U_, struct iscsi_pdu 
                 pdu->outdata.data[32 + 13] = 3;
                 break;
         }
-        return 0;
+out:
+        return iscsi_drv_orig.queue_pdu(iscsi, pdu);
 }
 
 void
@@ -61,8 +63,10 @@ test_compareandwrite_invalid_dataout_size(void)
                 return;
         }
 
-        local_iscsi_queue_pdu = my_iscsi_queue_pdu;
-        
+        /* override transport queue_pdu callback for PDU manipulation */
+        iscsi_drv_orig = *sd->iscsi_ctx->drv;
+        sd->iscsi_ctx->drv->queue_pdu = my_iscsi_queue_pdu;
+
         logging(LOG_VERBOSE, LOG_BLANK_LINE);
         logging(LOG_VERBOSE, "Test that COMPAREANDWRITE fails for invalid "
                 "(too small/too large) DataOut sizes.");
@@ -89,4 +93,6 @@ test_compareandwrite_invalid_dataout_size(void)
                         block_size, 0, 0, 0, 0,
                         EXPECT_STATUS_GENERIC_BAD);
 
+        /* restore transport callbacks */
+        *(sd->iscsi_ctx->drv) = iscsi_drv_orig;
 }

--- a/test-tool/test_iscsi_cmdsn_toolow.c
+++ b/test-tool/test_iscsi_cmdsn_toolow.c
@@ -25,6 +25,7 @@
 #include "iscsi-test-cu.h"
 
 static int change_cmdsn;
+static struct iscsi_transport iscsi_drv_orig;
 
 static int my_iscsi_queue_pdu(struct iscsi_context *iscsi, struct iscsi_pdu *pdu)
 {
@@ -40,7 +41,7 @@ static int my_iscsi_queue_pdu(struct iscsi_context *iscsi, struct iscsi_pdu *pdu
         }
 
         change_cmdsn = 0;        
-        return 0;
+        return iscsi_drv_orig.queue_pdu(iscsi, pdu);
 }
 
 void test_iscsi_cmdsn_toolow(void)
@@ -64,7 +65,9 @@ void test_iscsi_cmdsn_toolow(void)
 
         sd->iscsi_ctx->use_immediate_data = ISCSI_IMMEDIATE_DATA_NO;
         sd->iscsi_ctx->target_max_recv_data_segment_length = block_size;
-        local_iscsi_queue_pdu = my_iscsi_queue_pdu;
+        /* override transport queue_pdu callback for PDU manipulation */
+        iscsi_drv_orig = *sd->iscsi_ctx->drv;
+        sd->iscsi_ctx->drv->queue_pdu = my_iscsi_queue_pdu;
         change_cmdsn = 1;
         /* we don't want autoreconnect since some targets will incorrectly
          * drop the connection on this condition.
@@ -81,10 +84,11 @@ void test_iscsi_cmdsn_toolow(void)
                 logging(LOG_VERBOSE, "[FAILURE] We got a response from the target but SMDSN was outside of the window.");
         }
 
-        
-
         iscsi_set_noautoreconnect(sd->iscsi_ctx, 0);
         logging(LOG_VERBOSE, "Send a TESTUNITREADY with CMDSN == EXPCMDSN. should work again");
         TESTUNITREADY(sd,
                       EXPECT_STATUS_GOOD);
+
+        /* restore transport callbacks */
+        *(sd->iscsi_ctx->drv) = iscsi_drv_orig;
 }

--- a/test-tool/test_iscsi_datasn_invalid.c
+++ b/test-tool/test_iscsi_datasn_invalid.c
@@ -25,13 +25,14 @@
 #include "iscsi-test-cu.h"
 
 static int change_datasn;
+static struct iscsi_transport iscsi_drv_orig;
 
-static int my_iscsi_queue_pdu(struct iscsi_context *iscsi _U_, struct iscsi_pdu *pdu _U_)
+static int my_iscsi_queue_pdu(struct iscsi_context *iscsi, struct iscsi_pdu *pdu)
 {
         uint32_t datasn;
 
         if (pdu->outdata.data[0] != ISCSI_PDU_DATA_OUT) {
-                return 0;
+                goto out;
         }
         switch (change_datasn) {
         case 1:
@@ -52,11 +53,12 @@ static int my_iscsi_queue_pdu(struct iscsi_context *iscsi _U_, struct iscsi_pdu 
                 scsi_set_uint32(&pdu->outdata.data[36], 1 - datasn);
                 break;
         }
-        return 0;
+out:
+        return iscsi_drv_orig.queue_pdu(iscsi, pdu);
 }
 
 void test_iscsi_datasn_invalid(void)
-{ 
+{
         int ret;
 
         CHECK_FOR_DATALOSS;
@@ -77,7 +79,9 @@ void test_iscsi_datasn_invalid(void)
 
         sd->iscsi_ctx->use_immediate_data = ISCSI_IMMEDIATE_DATA_NO;
         sd->iscsi_ctx->target_max_recv_data_segment_length = block_size;
-        local_iscsi_queue_pdu = my_iscsi_queue_pdu;
+        /* override transport queue_pdu callback for PDU manipulation */
+        iscsi_drv_orig = *sd->iscsi_ctx->drv;
+        sd->iscsi_ctx->drv->queue_pdu = my_iscsi_queue_pdu;
         iscsi_set_noautoreconnect(sd->iscsi_ctx, 1);
         iscsi_set_timeout(sd->iscsi_ctx, 3);
 
@@ -89,81 +93,63 @@ void test_iscsi_datasn_invalid(void)
         if (ret == -2) {
                 logging(LOG_NORMAL, "[SKIPPED] WRITE10 is not implemented.");
                 CU_PASS("WRITE10 is not implemented.");
-                local_iscsi_queue_pdu = NULL;
-                return;
-        }        
+                goto out_ctx_restore;
+        }
         CU_ASSERT_NOT_EQUAL(ret, 0);
 
+        /* avoid changing DataSN during reconnect */
+        *(sd->iscsi_ctx->drv) = iscsi_drv_orig;
         iscsi_set_noautoreconnect(sd->iscsi_ctx, 0);
-
 
         logging(LOG_VERBOSE, "Send Data-Out PDU with DataSN==27. Should fail");
         change_datasn = 2;
 
         sd->iscsi_ctx->use_immediate_data = ISCSI_IMMEDIATE_DATA_NO;
         sd->iscsi_ctx->target_max_recv_data_segment_length = block_size;
-        local_iscsi_queue_pdu = my_iscsi_queue_pdu;
+        sd->iscsi_ctx->drv->queue_pdu = my_iscsi_queue_pdu;
         iscsi_set_noautoreconnect(sd->iscsi_ctx, 1);
         iscsi_set_timeout(sd->iscsi_ctx, 3);
 
         ret = write10(sd, 100, block_size,
                       block_size, 0, 0, 0, 0, 0, scratch,
                       EXPECT_STATUS_GOOD);
-        if (ret == -2) {
-                logging(LOG_NORMAL, "[SKIPPED] WRITE10 is not implemented.");
-                CU_PASS("WRITE10 is not implemented.");
-                local_iscsi_queue_pdu = NULL;
-                return;
-        }        
         CU_ASSERT_NOT_EQUAL(ret, 0);
 
+        *(sd->iscsi_ctx->drv) = iscsi_drv_orig;
         iscsi_set_noautoreconnect(sd->iscsi_ctx, 0);
-
 
         logging(LOG_VERBOSE, "Send Data-Out PDU with DataSN==-1. Should fail");
         change_datasn = 3;
 
         sd->iscsi_ctx->use_immediate_data = ISCSI_IMMEDIATE_DATA_NO;
         sd->iscsi_ctx->target_max_recv_data_segment_length = block_size;
-        local_iscsi_queue_pdu = my_iscsi_queue_pdu;
+        sd->iscsi_ctx->drv->queue_pdu = my_iscsi_queue_pdu;
         iscsi_set_noautoreconnect(sd->iscsi_ctx, 1);
         iscsi_set_timeout(sd->iscsi_ctx, 3);
 
         ret = write10(sd, 100, block_size,
                       block_size, 0, 0, 0, 0, 0, scratch,
                       EXPECT_STATUS_GOOD);
-        if (ret == -2) {
-                logging(LOG_NORMAL, "[SKIPPED] WRITE10 is not implemented.");
-                CU_PASS("WRITE10 is not implemented.");
-                local_iscsi_queue_pdu = NULL;
-                return;
-        }        
         CU_ASSERT_NOT_EQUAL(ret, 0);
 
+        *(sd->iscsi_ctx->drv) = iscsi_drv_orig;
         iscsi_set_noautoreconnect(sd->iscsi_ctx, 0);
-
-
 
         logging(LOG_VERBOSE, "Send Data-Out PDU's in reverse order (DataSN == 1,0). Should fail");
         change_datasn = 4;
 
         sd->iscsi_ctx->use_immediate_data = ISCSI_IMMEDIATE_DATA_NO;
         sd->iscsi_ctx->target_max_recv_data_segment_length = block_size;
-        local_iscsi_queue_pdu = my_iscsi_queue_pdu;
+        sd->iscsi_ctx->drv->queue_pdu = my_iscsi_queue_pdu;
         iscsi_set_noautoreconnect(sd->iscsi_ctx, 1);
         iscsi_set_timeout(sd->iscsi_ctx, 3);
 
         ret = write10(sd, 100, 2 * block_size,
                       block_size, 0, 0, 0, 0, 0, scratch,
                       EXPECT_STATUS_GOOD);
-        if (ret == -2) {
-                logging(LOG_NORMAL, "[SKIPPED] WRITE10 is not implemented.");
-                CU_PASS("WRITE10 is not implemented.");
-                local_iscsi_queue_pdu = NULL;
-                return;
-        }        
         CU_ASSERT_NOT_EQUAL(ret, 0);
-
-        local_iscsi_queue_pdu = NULL;
+out_ctx_restore:
+        /* restore transport callbacks and autoreconnect */
+        *(sd->iscsi_ctx->drv) = iscsi_drv_orig;
         iscsi_set_noautoreconnect(sd->iscsi_ctx, 0);
 }

--- a/test-tool/test_sanitize_block_erase_reserved.c
+++ b/test-tool/test_sanitize_block_erase_reserved.c
@@ -56,6 +56,13 @@ void test_sanitize_block_erase_reserved(void)
 
         CHECK_FOR_SANITIZE;
         CHECK_FOR_DATALOSS;
+        if (sd->iscsi_ctx == NULL) {
+                const char *err = "[SKIPPED] This test is "
+                        "only supported for iSCSI backends";
+                logging(LOG_NORMAL, "%s", err);
+                CU_PASS(err);
+                return;
+        }
 
         local_iscsi_queue_pdu = my_iscsi_queue_pdu;
 

--- a/test-tool/test_sanitize_block_erase_reserved.c
+++ b/test-tool/test_sanitize_block_erase_reserved.c
@@ -25,8 +25,9 @@
 #include "iscsi-test-cu.h"
 
 static int change_num;
+static struct iscsi_transport iscsi_drv_orig;
 
-static int my_iscsi_queue_pdu(struct iscsi_context *iscsi _U_, struct iscsi_pdu *pdu)
+static int my_iscsi_queue_pdu(struct iscsi_context *iscsi, struct iscsi_pdu *pdu)
 {
         switch (change_num) {
         case 1:
@@ -43,12 +44,12 @@ static int my_iscsi_queue_pdu(struct iscsi_context *iscsi _U_, struct iscsi_pdu 
                 break;
         }
 
-        change_num = 0;        
-        return 0;
+        change_num = 0;
+        return iscsi_drv_orig.queue_pdu(iscsi, pdu);
 }
 
 void test_sanitize_block_erase_reserved(void)
-{ 
+{
         int i;
 
         logging(LOG_VERBOSE, LOG_BLANK_LINE);
@@ -64,8 +65,9 @@ void test_sanitize_block_erase_reserved(void)
                 return;
         }
 
-        local_iscsi_queue_pdu = my_iscsi_queue_pdu;
-
+        /* override transport queue_pdu callback for PDU manipulation */
+        iscsi_drv_orig = *sd->iscsi_ctx->drv;
+        sd->iscsi_ctx->drv->queue_pdu = my_iscsi_queue_pdu;
 
         logging(LOG_VERBOSE, "Send SANITIZE command with the reserved "
                 "bit in byte 1 set to 1");
@@ -81,4 +83,7 @@ void test_sanitize_block_erase_reserved(void)
                 SANITIZE(sd, 0, 0, SCSI_SANITIZE_BLOCK_ERASE, 0, NULL,
                          EXPECT_INVALID_FIELD_IN_CDB);
         }
+
+        /* restore transport callbacks */
+        *(sd->iscsi_ctx->drv) = iscsi_drv_orig;
 }

--- a/test-tool/test_sanitize_crypto_erase_reserved.c
+++ b/test-tool/test_sanitize_crypto_erase_reserved.c
@@ -56,6 +56,13 @@ void test_sanitize_crypto_erase_reserved(void)
 
         CHECK_FOR_SANITIZE;
         CHECK_FOR_DATALOSS;
+        if (sd->iscsi_ctx == NULL) {
+                const char *err = "[SKIPPED] This test is "
+                        "only supported for iSCSI backends";
+                logging(LOG_NORMAL, "%s", err);
+                CU_PASS(err);
+                return;
+        }
 
         local_iscsi_queue_pdu = my_iscsi_queue_pdu;
 

--- a/test-tool/test_sanitize_overwrite_reserved.c
+++ b/test-tool/test_sanitize_overwrite_reserved.c
@@ -67,6 +67,13 @@ void test_sanitize_overwrite_reserved(void)
 
         CHECK_FOR_SANITIZE;
         CHECK_FOR_DATALOSS;
+        if (sd->iscsi_ctx == NULL) {
+                const char *err = "[SKIPPED] This test is "
+                        "only supported for iSCSI backends";
+                logging(LOG_NORMAL, "%s", err);
+                CU_PASS(err);
+                return;
+        }
 
         local_iscsi_queue_pdu = my_iscsi_queue_pdu;
 

--- a/test-tool/test_sanitize_overwrite_reserved.c
+++ b/test-tool/test_sanitize_overwrite_reserved.c
@@ -26,8 +26,9 @@
 #include "iscsi-test-cu.h"
 
 static int change_num;
+static struct iscsi_transport iscsi_drv_orig;
 
-static int my_iscsi_queue_pdu(struct iscsi_context *iscsi _U_, struct iscsi_pdu *pdu)
+static int my_iscsi_queue_pdu(struct iscsi_context *iscsi, struct iscsi_pdu *pdu)
 {
         switch (change_num) {
         case 1:
@@ -44,12 +45,12 @@ static int my_iscsi_queue_pdu(struct iscsi_context *iscsi _U_, struct iscsi_pdu 
                 break;
         }
 
-        change_num = 0;        
-        return 0;
+        change_num = 0;
+        return iscsi_drv_orig.queue_pdu(iscsi, pdu);
 }
 
 void test_sanitize_overwrite_reserved(void)
-{ 
+{
         int i;
         struct iscsi_data data;
 
@@ -75,7 +76,9 @@ void test_sanitize_overwrite_reserved(void)
                 return;
         }
 
-        local_iscsi_queue_pdu = my_iscsi_queue_pdu;
+        /* override transport queue_pdu callback for PDU manipulation */
+        iscsi_drv_orig = *sd->iscsi_ctx->drv;
+        sd->iscsi_ctx->drv->queue_pdu = my_iscsi_queue_pdu;
 
         logging(LOG_VERBOSE, "Send SANITIZE command with the reserved "
                 "bit in byte 1 set to 1");
@@ -91,4 +94,7 @@ void test_sanitize_overwrite_reserved(void)
                 SANITIZE(sd, 0, 0, SCSI_SANITIZE_OVERWRITE, data.size, &data,
                          EXPECT_INVALID_FIELD_IN_CDB);
         }
+
+        /* restore transport callbacks */
+        *(sd->iscsi_ctx->drv) = iscsi_drv_orig;
 }


### PR DESCRIPTION
test-tool/iscsi-support.c includes it's own iscsi_queue_pdu() function, which can be used by tests for intercepting PDU dispatch and falling through to the libiscsi path via dlsym() lookup.
With https://github.com/sahlberg/libiscsi/issues/297 we want to allow the test tool to directly use low-level libiscsi functions, which is complicated by the duplicate iscsi_queue_pdu() symbol.
The iSCSI context already includes a transport-specific queue_pdu() callback, so use that for overloading instead.