### PR TITLE
test-tool: add and link against libiscsipriv convenience library

### DIFF
--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -1,18 +1,37 @@
-lib_LTLIBRARIES = libiscsi.la
+# test-tool needs to access private symbols, so build a noinst convenience
+# library.
+noinst_LTLIBRARIES = libiscsipriv.la
 
-libiscsi_la_SOURCES = \
+libiscsipriv_la_SOURCES = \
 	connect.c crc32c.c discovery.c init.c \
 	login.c nop.c pdu.c iscsi-command.c \
 	scsi-lowlevel.c socket.c sync.c task_mgmt.c \
 	logging.c
 
 if !HAVE_LIBGCRYPT
-libiscsi_la_SOURCES += md5.c
+libiscsipriv_la_SOURCES += md5.c
 endif
 
 if HAVE_LINUX_ISER
-libiscsi_la_SOURCES += iser.c
+libiscsipriv_la_SOURCES += iser.c
 endif
+
+if HAVE_LINUX_ISER
+libiscsipriv_la_LDFLAGS = -libverbs -lrdmacm
+endif
+
+libiscsipriv_la_CPPFLAGS = -I${srcdir}/../include -I$(srcdir)/include \
+	"-D_U_=__attribute__((unused))" \
+	"-D_R_(A,B)=__attribute__((format(printf,A,B)))"
+
+AM_CFLAGS=$(WARN_CFLAGS)
+
+# The proper library just pulls in the convenience library and explicitly
+# specifies exported symbols.
+lib_LTLIBRARIES = libiscsi.la
+
+libiscsi_la_SOURCES =
+libiscsi_la_LIBADD = libiscsipriv.la
 
 SOCURRENT=9
 SOREVISON=0
@@ -21,15 +40,4 @@ libiscsi_la_LDFLAGS = \
 	-version-info $(SOCURRENT):$(SOREVISON):$(SOAGE) -bindir $(bindir) \
 	-no-undefined -export-symbols ${srcdir}/libiscsi.syms
 
-if HAVE_LINUX_ISER
-libiscsi_la_LDFLAGS += -libverbs -lrdmacm
-endif
-
-libiscsi_la_CPPFLAGS = -I${srcdir}/../include -I$(srcdir)/include \
-	"-D_U_=__attribute__((unused))" \
-	"-D_R_(A,B)=__attribute__((format(printf,A,B)))"
-
-AM_CFLAGS=$(WARN_CFLAGS)
-
 dist_noinst_DATA = libiscsi.syms libiscsi.def
-

--- a/test-tool/Makefile.am
+++ b/test-tool/Makefile.am
@@ -2,7 +2,7 @@ AM_CPPFLAGS=-I. -I${srcdir}/../include \
 	"-D_U_=__attribute__((unused)) " \
 	"-D_R_(A,B)=__attribute__((format(printf,A,B)))"
 AM_CFLAGS=$(WARN_CFLAGS)
-LDADD = ../lib/libiscsi.la
+LDADD = ../lib/libiscsipriv.la
 
 EXTRA_DIST = README
 

--- a/test-tool/test_iscsi_cmdsn_toohigh.c
+++ b/test-tool/test_iscsi_cmdsn_toohigh.c
@@ -31,7 +31,10 @@ static int my_iscsi_queue_pdu(struct iscsi_context *iscsi, struct iscsi_pdu *pdu
 {
         switch (change_cmdsn) {
         case 1:
-                /* change the cmdsn so it becomes too big */
+                /*
+		 * change the cmdsn so it becomes too big. TODO: use
+		 * iscsi_pdu_set_cmdsn(), which also changes pdu->cmdsn?
+		 */
                 scsi_set_uint32(&pdu->outdata.data[24], iscsi->maxcmdsn + 1);
                 /* fudge the cmdsn value back to where it should be if this
                  * pdu is ignored.
@@ -40,12 +43,12 @@ static int my_iscsi_queue_pdu(struct iscsi_context *iscsi, struct iscsi_pdu *pdu
                 break;
         }
 
-        change_cmdsn = 0;        
+        change_cmdsn = 0;
         return iscsi_drv_orig.queue_pdu(iscsi, pdu);
 }
 
 void test_iscsi_cmdsn_toohigh(void)
-{ 
+{
         int ret;
 
         logging(LOG_VERBOSE, LOG_BLANK_LINE);

--- a/test-tool/test_iscsi_cmdsn_toolow.c
+++ b/test-tool/test_iscsi_cmdsn_toolow.c
@@ -31,7 +31,10 @@ static int my_iscsi_queue_pdu(struct iscsi_context *iscsi, struct iscsi_pdu *pdu
 {
         switch (change_cmdsn) {
         case 1:
-                /* change the cmdsn so it becomes too big */
+                /*
+		 * change the cmdsn so it becomes too low. TODO: use
+		 * iscsi_pdu_set_cmdsn(), which also changes pdu->cmdsn?
+		 */
                 scsi_set_uint32(&pdu->outdata.data[24], iscsi->expcmdsn - 1);
                 /* fudge the cmdsn value back to where it should be if this
                  * pdu is ignored.
@@ -40,12 +43,12 @@ static int my_iscsi_queue_pdu(struct iscsi_context *iscsi, struct iscsi_pdu *pdu
                 break;
         }
 
-        change_cmdsn = 0;        
+        change_cmdsn = 0;
         return iscsi_drv_orig.queue_pdu(iscsi, pdu);
 }
 
 void test_iscsi_cmdsn_toolow(void)
-{ 
+{
         int ret;
 
         logging(LOG_VERBOSE, LOG_BLANK_LINE);

--- a/test-tool/test_iscsi_datasn_invalid.c
+++ b/test-tool/test_iscsi_datasn_invalid.c
@@ -37,20 +37,20 @@ static int my_iscsi_queue_pdu(struct iscsi_context *iscsi, struct iscsi_pdu *pdu
         switch (change_datasn) {
         case 1:
                 /* change DataSN to 0 */
-                scsi_set_uint32(&pdu->outdata.data[36], 0);
+                iscsi_pdu_set_datasn(pdu, 0);
                 break;
         case 2:
                 /* change DataSN to 27 */
-                scsi_set_uint32(&pdu->outdata.data[36], 27);
+                iscsi_pdu_set_datasn(pdu, 27);
                 break;
         case 3:
                 /* change DataSN to -1 */
-                scsi_set_uint32(&pdu->outdata.data[36], -1);
+                iscsi_pdu_set_datasn(pdu, -1);
                 break;
         case 4:
                 /* change DataSN from (0,1) to (1,0) */
                 datasn = scsi_get_uint32(&pdu->outdata.data[36]);
-                scsi_set_uint32(&pdu->outdata.data[36], 1 - datasn);
+                iscsi_pdu_set_datasn(pdu, 1 - datasn);
                 break;
         }
 out:


### PR DESCRIPTION
As a follow up to https://github.com/sahlberg/libiscsi/pull/299 , this patchset sees iscsi-test-cu statically link against a new libiscsipriv library, which allows tests to now make full use of internal libiscsi functionality for PDU mainipulation etc.

Only a single test has been changed to use the newly available symbols, but further tests for SendTargets and Nop-Out will follow.