### PR TITLE
Improve robustness of the code that restores .queue_pdu()

### DIFF
--- a/test-tool/iscsi-test-cu.c
+++ b/test-tool/iscsi-test-cu.c
@@ -730,6 +730,7 @@ static struct test_family families[] = {
  */
 struct scsi_task *task;
 unsigned char *read_write_buf;
+int (*orig_queue_pdu)(struct iscsi_context *iscsi, struct iscsi_pdu *pdu);
 
 static void
 print_usage(void)
@@ -825,11 +826,14 @@ test_setup(void)
 {
         task = NULL;
         read_write_buf = NULL;
+        orig_queue_pdu = sd->iscsi_ctx ? sd->iscsi_ctx->drv->queue_pdu : NULL;
 }
 
 void
 test_teardown(void)
 {
+        if (sd->iscsi_ctx)
+                sd->iscsi_ctx->drv->queue_pdu = orig_queue_pdu;
         free(read_write_buf);
         read_write_buf = NULL;
         scsi_free_scsi_task(task);

--- a/test-tool/iscsi-test-cu.h
+++ b/test-tool/iscsi-test-cu.h
@@ -35,6 +35,8 @@
 /* globals between setup, tests, and teardown */
 extern struct scsi_task *task;
 extern unsigned char *read_write_buf;
+extern int (*orig_queue_pdu)(struct iscsi_context *iscsi,
+                             struct iscsi_pdu *pdu);
 
 #ifndef HAVE_CU_SUITEINFO_PSETUPFUNC
 /* libcunit version 1 */

--- a/test-tool/test_compareandwrite_invalid_dataout_size.c
+++ b/test-tool/test_compareandwrite_invalid_dataout_size.c
@@ -27,7 +27,6 @@
 
 
 static int new_tl;
-static struct iscsi_transport iscsi_drv_orig;
 
 static int my_iscsi_queue_pdu(struct iscsi_context *iscsi, struct iscsi_pdu *pdu)
 {
@@ -45,7 +44,7 @@ static int my_iscsi_queue_pdu(struct iscsi_context *iscsi, struct iscsi_pdu *pdu
                 break;
         }
 out:
-        return iscsi_drv_orig.queue_pdu(iscsi, pdu);
+        return orig_queue_pdu(iscsi, pdu);
 }
 
 void
@@ -58,7 +57,6 @@ test_compareandwrite_invalid_dataout_size(void)
         CHECK_FOR_ISCSI(sd);
 
         /* override transport queue_pdu callback for PDU manipulation */
-        iscsi_drv_orig = *sd->iscsi_ctx->drv;
         sd->iscsi_ctx->drv->queue_pdu = my_iscsi_queue_pdu;
 
         logging(LOG_VERBOSE, LOG_BLANK_LINE);
@@ -86,7 +84,4 @@ test_compareandwrite_invalid_dataout_size(void)
                         scratch, 4 * block_size,
                         block_size, 0, 0, 0, 0,
                         EXPECT_STATUS_GENERIC_BAD);
-
-        /* restore transport callbacks */
-        *(sd->iscsi_ctx->drv) = iscsi_drv_orig;
 }

--- a/test-tool/test_iscsi_cmdsn_toohigh.c
+++ b/test-tool/test_iscsi_cmdsn_toohigh.c
@@ -25,7 +25,6 @@
 #include "iscsi-test-cu.h"
 
 static int change_cmdsn;
-static struct iscsi_transport iscsi_drv_orig;
 
 static int my_iscsi_queue_pdu(struct iscsi_context *iscsi, struct iscsi_pdu *pdu)
 {
@@ -44,7 +43,7 @@ static int my_iscsi_queue_pdu(struct iscsi_context *iscsi, struct iscsi_pdu *pdu
         }
 
         change_cmdsn = 0;
-        return iscsi_drv_orig.queue_pdu(iscsi, pdu);
+        return orig_queue_pdu(iscsi, pdu);
 }
 
 void test_iscsi_cmdsn_toohigh(void)
@@ -63,7 +62,6 @@ void test_iscsi_cmdsn_toohigh(void)
         sd->iscsi_ctx->use_immediate_data = ISCSI_IMMEDIATE_DATA_NO;
         sd->iscsi_ctx->target_max_recv_data_segment_length = block_size;
         /* override transport queue_pdu callback for PDU manipulation */
-        iscsi_drv_orig = *sd->iscsi_ctx->drv;
         sd->iscsi_ctx->drv->queue_pdu = my_iscsi_queue_pdu;
         change_cmdsn = 1;
         /* we don't want autoreconnect since some targets will incorrectly
@@ -85,7 +83,4 @@ void test_iscsi_cmdsn_toohigh(void)
         logging(LOG_VERBOSE, "Send a TESTUNITREADY with CMDSN == EXPCMDSN. should work again");
         TESTUNITREADY(sd,
                       EXPECT_STATUS_GOOD);
-
-        /* restore transport callbacks */
-        *(sd->iscsi_ctx->drv) = iscsi_drv_orig;
 }

--- a/test-tool/test_iscsi_cmdsn_toolow.c
+++ b/test-tool/test_iscsi_cmdsn_toolow.c
@@ -25,7 +25,6 @@
 #include "iscsi-test-cu.h"
 
 static int change_cmdsn;
-static struct iscsi_transport iscsi_drv_orig;
 
 static int my_iscsi_queue_pdu(struct iscsi_context *iscsi, struct iscsi_pdu *pdu)
 {
@@ -44,7 +43,7 @@ static int my_iscsi_queue_pdu(struct iscsi_context *iscsi, struct iscsi_pdu *pdu
         }
 
         change_cmdsn = 0;
-        return iscsi_drv_orig.queue_pdu(iscsi, pdu);
+        return orig_queue_pdu(iscsi, pdu);
 }
 
 void test_iscsi_cmdsn_toolow(void)
@@ -63,7 +62,6 @@ void test_iscsi_cmdsn_toolow(void)
         sd->iscsi_ctx->use_immediate_data = ISCSI_IMMEDIATE_DATA_NO;
         sd->iscsi_ctx->target_max_recv_data_segment_length = block_size;
         /* override transport queue_pdu callback for PDU manipulation */
-        iscsi_drv_orig = *sd->iscsi_ctx->drv;
         sd->iscsi_ctx->drv->queue_pdu = my_iscsi_queue_pdu;
         change_cmdsn = 1;
         /* we don't want autoreconnect since some targets will incorrectly
@@ -85,7 +83,4 @@ void test_iscsi_cmdsn_toolow(void)
         logging(LOG_VERBOSE, "Send a TESTUNITREADY with CMDSN == EXPCMDSN. should work again");
         TESTUNITREADY(sd,
                       EXPECT_STATUS_GOOD);
-
-        /* restore transport callbacks */
-        *(sd->iscsi_ctx->drv) = iscsi_drv_orig;
 }

--- a/test-tool/test_sanitize_block_erase_reserved.c
+++ b/test-tool/test_sanitize_block_erase_reserved.c
@@ -25,7 +25,6 @@
 #include "iscsi-test-cu.h"
 
 static int change_num;
-static struct iscsi_transport iscsi_drv_orig;
 
 static int my_iscsi_queue_pdu(struct iscsi_context *iscsi, struct iscsi_pdu *pdu)
 {
@@ -45,7 +44,7 @@ static int my_iscsi_queue_pdu(struct iscsi_context *iscsi, struct iscsi_pdu *pdu
         }
 
         change_num = 0;
-        return iscsi_drv_orig.queue_pdu(iscsi, pdu);
+        return orig_queue_pdu(iscsi, pdu);
 }
 
 void test_sanitize_block_erase_reserved(void)
@@ -60,7 +59,6 @@ void test_sanitize_block_erase_reserved(void)
         CHECK_FOR_ISCSI(sd);
 
         /* override transport queue_pdu callback for PDU manipulation */
-        iscsi_drv_orig = *sd->iscsi_ctx->drv;
         sd->iscsi_ctx->drv->queue_pdu = my_iscsi_queue_pdu;
 
         logging(LOG_VERBOSE, "Send SANITIZE command with the reserved "
@@ -77,7 +75,4 @@ void test_sanitize_block_erase_reserved(void)
                 SANITIZE(sd, 0, 0, SCSI_SANITIZE_BLOCK_ERASE, 0, NULL,
                          EXPECT_INVALID_FIELD_IN_CDB);
         }
-
-        /* restore transport callbacks */
-        *(sd->iscsi_ctx->drv) = iscsi_drv_orig;
 }

--- a/test-tool/test_sanitize_crypto_erase_reserved.c
+++ b/test-tool/test_sanitize_crypto_erase_reserved.c
@@ -25,7 +25,6 @@
 #include "iscsi-test-cu.h"
 
 static int change_num;
-static struct iscsi_transport iscsi_drv_orig;
 
 static int my_iscsi_queue_pdu(struct iscsi_context *iscsi, struct iscsi_pdu *pdu)
 {
@@ -45,7 +44,7 @@ static int my_iscsi_queue_pdu(struct iscsi_context *iscsi, struct iscsi_pdu *pdu
         }
 
         change_num = 0;
-        return iscsi_drv_orig.queue_pdu(iscsi, pdu);
+        return orig_queue_pdu(iscsi, pdu);
 }
 
 void test_sanitize_crypto_erase_reserved(void)
@@ -60,7 +59,6 @@ void test_sanitize_crypto_erase_reserved(void)
         CHECK_FOR_ISCSI(sd);
 
         /* override transport queue_pdu callback for PDU manipulation */
-        iscsi_drv_orig = *sd->iscsi_ctx->drv;
         sd->iscsi_ctx->drv->queue_pdu = my_iscsi_queue_pdu;
 
         logging(LOG_VERBOSE, "Send SANITIZE command with the reserved "
@@ -77,7 +75,4 @@ void test_sanitize_crypto_erase_reserved(void)
                 SANITIZE(sd, 0, 0, SCSI_SANITIZE_CRYPTO_ERASE, 0, NULL,
                          EXPECT_INVALID_FIELD_IN_CDB);
         }
-
-        /* restore transport callbacks */
-        *(sd->iscsi_ctx->drv) = iscsi_drv_orig;
 }

--- a/test-tool/test_sanitize_overwrite_reserved.c
+++ b/test-tool/test_sanitize_overwrite_reserved.c
@@ -26,7 +26,6 @@
 #include "iscsi-test-cu.h"
 
 static int change_num;
-static struct iscsi_transport iscsi_drv_orig;
 
 static int my_iscsi_queue_pdu(struct iscsi_context *iscsi, struct iscsi_pdu *pdu)
 {
@@ -46,7 +45,7 @@ static int my_iscsi_queue_pdu(struct iscsi_context *iscsi, struct iscsi_pdu *pdu
         }
 
         change_num = 0;
-        return iscsi_drv_orig.queue_pdu(iscsi, pdu);
+        return orig_queue_pdu(iscsi, pdu);
 }
 
 void test_sanitize_overwrite_reserved(void)
@@ -71,7 +70,6 @@ void test_sanitize_overwrite_reserved(void)
         CHECK_FOR_ISCSI(sd);
 
         /* override transport queue_pdu callback for PDU manipulation */
-        iscsi_drv_orig = *sd->iscsi_ctx->drv;
         sd->iscsi_ctx->drv->queue_pdu = my_iscsi_queue_pdu;
 
         logging(LOG_VERBOSE, "Send SANITIZE command with the reserved "
@@ -88,7 +86,4 @@ void test_sanitize_overwrite_reserved(void)
                 SANITIZE(sd, 0, 0, SCSI_SANITIZE_OVERWRITE, data.size, &data,
                          EXPECT_INVALID_FIELD_IN_CDB);
         }
-
-        /* restore transport callbacks */
-        *(sd->iscsi_ctx->drv) = iscsi_drv_orig;
 }


### PR DESCRIPTION
In my tests I hit a stack overflow caused by infinite recursion of
.queue_pdu() calls, caused by .queue_pdu() not being restored in an
error path. Make the approach for restoring .queue_pdu() more robust.

Signed-off-by: Bart Van Assche <bvanassche@acm.org>