### PR TITLE
Fix data segment length comparison to unsigned long

### DIFF
--- a/lib/login.c
+++ b/lib/login.c
@@ -1242,11 +1242,11 @@ iscsi_process_login_reply(struct iscsi_context *iscsi, struct iscsi_pdu *pdu,
 
         /* iSER specific keys */
         if (!strncmp(ptr, "InitiatorRecvDataSegmentLength=", 31)) {
-			iscsi->initiator_max_recv_data_segment_length = MIN(strtol(ptr + 31, NULL, 10),
+			iscsi->initiator_max_recv_data_segment_length = MIN(strtoul(ptr + 31, NULL, 10),
                                                              iscsi->initiator_max_recv_data_segment_length);
         }
         if (!strncmp(ptr, "TargetRecvDataSegmentLength=", 28)) {
-			iscsi->target_max_recv_data_segment_length = MIN(strtol(ptr + 28, NULL, 10),
+			iscsi->target_max_recv_data_segment_length = MIN(strtoul(ptr + 28, NULL, 10),
                                                              iscsi->target_max_recv_data_segment_length);
         }
 


### PR DESCRIPTION
In logic.c, data segment parameters in the text segment are converted to
signed longs.  Changing from strtol -> strtoul fixes compiler errors on
certain platforms that warn against comparing a signed long with
uint32_t using MIN.