### PR TITLE
test-tool: Use 'extern int' for declaring global variables in headers

### DIFF
--- a/test-tool/iscsi-support.h
+++ b/test-tool/iscsi-support.h
@@ -53,17 +53,17 @@ extern const char *initiatorname2;
 #define EXPECT_RESERVATION_CONFLICT SCSI_STATUS_RESERVATION_CONFLICT, 0, NULL, 0
 #define EXPECT_COPY_ABORTED SCSI_STATUS_CHECK_CONDITION, SCSI_SENSE_COPY_ABORTED, copy_aborted_ascqs, 3
 
-int no_medium_ascqs[3];
-int lba_oob_ascqs[1];
-int invalid_cdb_ascqs[2];
-int param_list_len_err_ascqs[1];
-int too_many_desc_ascqs[2];
-int unsupp_desc_code_ascqs[2];
-int write_protect_ascqs[3];
-int sanitize_ascqs[1];
-int removal_ascqs[1];
-int miscompare_ascqs[1];
-int copy_aborted_ascqs[3];
+extern int no_medium_ascqs[3];
+extern int lba_oob_ascqs[1];
+extern int invalid_cdb_ascqs[2];
+extern int param_list_len_err_ascqs[1];
+extern int too_many_desc_ascqs[2];
+extern int unsupp_desc_code_ascqs[2];
+extern int write_protect_ascqs[3];
+extern int sanitize_ascqs[1];
+extern int removal_ascqs[1];
+extern int miscompare_ascqs[1];
+extern int copy_aborted_ascqs[3];
 
 extern int loglevel;
 #define LOG_SILENT  0


### PR DESCRIPTION
Without this, linking fails on Fedora rawhide. Example:

...
/usr/bin/ld: test_async_lu_reset_simple.o:/root/libiscsi/libiscsi.git/test-tool/iscsi-support.h:59: multiple definition of `param_list_len_err_ascqs'; iscsi-test-cu.o:/root/libiscsi/libiscsi.git/test-tool/iscsi-support.h:59: first defined here
/usr/bin/ld: test_async_lu_reset_simple.o:/root/libiscsi/libiscsi.git/test-tool/iscsi-support.h:58: multiple definition of `invalid_cdb_ascqs'; iscsi-test-cu.o:/root/libiscsi/libiscsi.git/test-tool/iscsi-support.h:58: first defined here
...