### PR TITLE
specify number of blocks in write_same command

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,21 @@
+language: c
+
+os:
+  - linux
+  - osx
+
+addons:
+  apt:
+    packages:
+      - dpkg
+      - gcc
+      - libcunit1-dev
+      - libibverbs-dev
+      - librdmacm-dev
+      - make
+      - pkg-config
+
+sudo: required
+
+script:
+  ci/build.sh

--- a/aros/iscsi-ls.c
+++ b/aros/iscsi-ls.c
@@ -37,10 +37,6 @@
 #include "iscsi.h"
 #include "scsi-lowlevel.h"
 
-#ifndef discard_const
-#define discard_const(ptr) ((void *)((intptr_t)(ptr)))
-#endif
-
 int showluns;
 const char *initiator = "iqn.2007-10.com.github:sahlberg:libiscsi:iscsi-ls";
 
@@ -318,7 +314,7 @@ int main(int argc, char *argv[])
 	struct iscsi_context *iscsi;
 	struct iscsi_url *iscsi_url = NULL;
 	struct client_state state;
-	const char *url = NULL;
+	char *url = NULL;
 	int c;
 	static int show_help = 0, show_usage = 0, debug = 0;
 
@@ -384,9 +380,7 @@ int main(int argc, char *argv[])
 
 	iscsi_url = iscsi_parse_portal_url(iscsi, url);
 
-	if (url) {
-		free(discard_const(url));
-	}
+        free(url);
 
 	if (iscsi_url == NULL) {
 		fprintf(stderr, "Failed to parse URL: %s\n",

--- a/ci/build.sh
+++ b/ci/build.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+./autogen.sh &&
+    ./configure --enable-manpages --enable-test-tool --enable-tests \
+		--enable-examples &&
+    make &&
+    sudo make install

--- a/configure.ac
+++ b/configure.ac
@@ -28,7 +28,7 @@ AC_ARG_ENABLE([werror], [AS_HELP_STRING([--disable-werror],
               [Disables building with -Werror by default])])
 
 if test "$ac_cv_prog_gcc" = yes; then
-   WARN_CFLAGS="-Wall -W -Wshadow -Wstrict-prototypes -Wpointer-arith -Wcast-align -Wno-strict-aliasing -Wvla"
+   WARN_CFLAGS="-Wall -W -Wshadow -Wstrict-prototypes -Wpointer-arith -Wcast-align -Wcast-qual -Wno-strict-aliasing -Wvla"
    WARN_CFLAGS="$WARN_CFLAGS -Wno-unknown-warning-option -Wno-stringop-truncation"
    if test "x$enable_werror" != "xno"; then
        WARN_CFLAGS="$WARN_CFLAGS -Werror"

--- a/include/iscsi-private.h
+++ b/include/iscsi-private.h
@@ -361,7 +361,7 @@ void iscsi_decrement_iface_rr(void);
 		} \
 	} while (0)
 
-void
+void __attribute__((format(printf, 3, 4)))
 iscsi_log_message(struct iscsi_context *iscsi, int level, const char *format, ...);
 
 void

--- a/include/iscsi-private.h
+++ b/include/iscsi-private.h
@@ -31,10 +31,6 @@
 extern "C" {
 #endif
 
-#ifndef discard_const
-#define discard_const(ptr) ((void *)((intptr_t)(ptr)))
-#endif
-
 #ifndef MIN
 #define MIN(a, b) (((a) < (b)) ? (a) : (b))
 #endif

--- a/include/iscsi.h
+++ b/include/iscsi.h
@@ -549,12 +549,12 @@ EXTERN int iscsi_logout_sync(struct iscsi_context *iscsi);
 
 struct iscsi_target_portal {
        struct iscsi_target_portal *next;
-       const char *portal;
+       char *portal;
 };
 
 struct iscsi_discovery_address {
        struct iscsi_discovery_address *next;
-       const char *target_name;
+       char *target_name;
        struct iscsi_target_portal *portals;
 };
 

--- a/lib/connect.c
+++ b/lib/connect.c
@@ -418,6 +418,14 @@ int iscsi_reconnect(struct iscsi_context *iscsi)
 		return -1;
 	}
 
+	/* default transport is initialized as TCP in iscsi_create_context,
+	   we have to overwrite transport in new iscsi as old iscsi.
+	 */
+	if (iscsi_init_transport(tmp_iscsi, iscsi->transport)) {
+		ISCSI_LOG(iscsi, 2, "failed to initializing transport for reconnection");
+		return -1;
+	}
+
 	ISCSI_LOG(iscsi, 2, "reconnect initiated");
 
 	iscsi_set_targetname(tmp_iscsi, iscsi->target_name);

--- a/lib/discovery.c
+++ b/lib/discovery.c
@@ -89,14 +89,14 @@ iscsi_free_discovery_addresses(struct iscsi_context *iscsi, struct iscsi_discove
 	while (addresses != NULL) {
 		struct iscsi_discovery_address *next = addresses->next;
 
-		iscsi_free(iscsi, discard_const(addresses->target_name));
+		iscsi_free(iscsi, addresses->target_name);
 		addresses->target_name = NULL;
 
 		while (addresses->portals != NULL) {
 			struct iscsi_target_portal *next_portal = addresses->portals->next;
 
-			iscsi_free(iscsi, discard_const(addresses->portals->portal));
-			iscsi_free(iscsi, discard_const(addresses->portals));
+			iscsi_free(iscsi, addresses->portals->portal);
+			iscsi_free(iscsi, addresses->portals);
 
 			addresses->portals = next_portal;
 		}

--- a/lib/discovery.c
+++ b/lib/discovery.c
@@ -37,7 +37,7 @@ iscsi_discovery_async(struct iscsi_context *iscsi, iscsi_command_cb cb,
 		      void *private_data)
 {
 	struct iscsi_pdu *pdu;
-	char *str;
+	const char *str;
 
 	pdu = iscsi_allocate_pdu(iscsi, ISCSI_PDU_TEXT_REQUEST,
 				 ISCSI_PDU_TEXT_RESPONSE,
@@ -62,9 +62,9 @@ iscsi_discovery_async(struct iscsi_context *iscsi, iscsi_command_cb cb,
 	iscsi_pdu_set_ttt(pdu, 0xffffffff);
 
 	/* sendtargets */
-	str = (char *)"SendTargets=All";
-	if (iscsi_pdu_add_data(iscsi, pdu, (unsigned char *)str, strlen(str)+1)
-	    != 0) {
+	str = "SendTargets=All";
+	if (iscsi_pdu_add_data(iscsi, pdu, (const unsigned char *)str,
+                               strlen(str) + 1) != 0) {
 		iscsi_set_error(iscsi, "Out-of-memory: pdu add data failed.");
 		iscsi->drv->free_pdu(iscsi, pdu);
 		return -1;

--- a/lib/init.c
+++ b/lib/init.c
@@ -218,7 +218,7 @@ iscsi_create_context(const char *initiator_name)
 
 	/* initalize transport of context */
 	if (iscsi_init_transport(iscsi, TCP_TRANSPORT)) {
-		iscsi_set_error(iscsi, "Failed allocating transport");
+		free(iscsi);
 		return NULL;
 	}
 

--- a/lib/init.c
+++ b/lib/init.c
@@ -393,9 +393,7 @@ iscsi_destroy_context(struct iscsi_context *iscsi)
 		return 0;
 	}
 
-	if (iscsi->fd != -1) {
-		iscsi_disconnect(iscsi);
-	}
+	iscsi_disconnect(iscsi);
 
 	iscsi_cancel_pdus(iscsi);
 

--- a/lib/init.c
+++ b/lib/init.c
@@ -289,7 +289,7 @@ iscsi_create_context(const char *initiator_name)
 	while (iscsi->smalloc_size < required) {
 		iscsi->smalloc_size <<= 1;
 	}
-	ISCSI_LOG(iscsi,5,"small allocation size is %d byte", iscsi->smalloc_size);
+	ISCSI_LOG(iscsi,5,"small allocation size is %lu byte", iscsi->smalloc_size);
 
 	ca = getenv("LIBISCSI_CACHE_ALLOCATIONS");
 	if (!ca || atoi(ca) != 0) {

--- a/lib/iser.c
+++ b/lib/iser.c
@@ -17,6 +17,7 @@
 
 #include <sys/types.h>
 #include <sys/stat.h>
+#include <sys/prctl.h>
 #include <fcntl.h>
 #include <stdlib.h>
 #include "slist.h"
@@ -47,6 +48,9 @@
 
 
 #ifdef __linux
+
+/* the  name  can  be up to 16 bytes long, including the terminating null byte*/
+#define ISER_CM_THREAD_NAME "iscsi_cm_thread"
 
 /* MUST keep in sync with socket.c */
 union socket_address {
@@ -1369,6 +1373,9 @@ static void *cm_thread(void *arg)
 	struct rdma_cm_event event_copy;
 	int ret;
 	struct iscsi_context *iscsi = iser_conn->cma_id->context;
+
+	/* supported since Linux 2.6.9, not fatal error, ignore return value */
+	prctl(PR_SET_NAME, ISER_CM_THREAD_NAME);
 
 	while (1) {
 		ret = rdma_get_cm_event(iser_conn->cma_channel, &iser_conn->cma_event);

--- a/lib/iser.c
+++ b/lib/iser.c
@@ -1036,7 +1036,7 @@ iser_reg_mr(struct iser_conn *iser_conn)
 
 	for (i = 0 ; i < NUM_MRS ; i++) {
 
-			tx_desc = iscsi_malloc(iscsi, sizeof(*tx_desc));
+			tx_desc = iscsi_zmalloc(iscsi, sizeof(*tx_desc));
 			if (tx_desc == NULL) {
 				iscsi_set_error(iscsi, "Out-Of-Memory, failed to allocate data buffer");
 				return -1;
@@ -1478,7 +1478,7 @@ static iscsi_transport iscsi_transport_iser = {
 void iscsi_init_iser_transport(struct iscsi_context *iscsi)
 {
 	iscsi->drv = &iscsi_transport_iser;
-	iscsi->opaque = iscsi_malloc(iscsi, sizeof(struct iser_conn));
+	iscsi->opaque = iscsi_zmalloc(iscsi, sizeof(struct iser_conn));
 	iscsi->transport = ISER_TRANSPORT;
 	/* Update iSCSI params as per iSER transport */
 	iscsi->initiator_max_recv_data_segment_length = ISCSI_DEF_MAX_RECV_SEG_LEN;

--- a/lib/iser.c
+++ b/lib/iser.c
@@ -198,6 +198,7 @@ iser_free_iser_conn_res(struct iser_conn *iser_conn, bool destroy)
 
 		if (iser_conn->cmthread) {
 			pthread_cancel(iser_conn->cmthread);
+			pthread_join(iser_conn->cmthread, NULL);
 			iser_conn->cmthread = 0;
 		}
 

--- a/lib/login.c
+++ b/lib/login.c
@@ -54,9 +54,7 @@ iscsi_login_add_initiatorname(struct iscsi_context *iscsi, struct iscsi_pdu *pdu
 	char str[MAX_STRING_SIZE+1];
 
 	/* We only send InitiatorName during opneg or the first leg of secneg */
-	if ((iscsi->current_phase != ISCSI_PDU_LOGIN_CSG_OPNEG
-	&& iscsi->secneg_phase != ISCSI_LOGIN_SECNEG_PHASE_OFFER_CHAP)
-	|| iscsi->secneg_phase != ISCSI_LOGIN_SECNEG_PHASE_OFFER_CHAP) {
+	if (iscsi->secneg_phase != ISCSI_LOGIN_SECNEG_PHASE_OFFER_CHAP) {
 		return 0;
 	}
 
@@ -78,9 +76,7 @@ iscsi_login_add_alias(struct iscsi_context *iscsi, struct iscsi_pdu *pdu)
 	char str[MAX_STRING_SIZE+1];
 
 	/* We only send InitiatorAlias during opneg or the first leg of secneg */
-	if ((iscsi->current_phase != ISCSI_PDU_LOGIN_CSG_OPNEG
-	&& iscsi->secneg_phase != ISCSI_LOGIN_SECNEG_PHASE_OFFER_CHAP)
-	|| iscsi->secneg_phase != ISCSI_LOGIN_SECNEG_PHASE_OFFER_CHAP) {
+	if (iscsi->secneg_phase != ISCSI_LOGIN_SECNEG_PHASE_OFFER_CHAP) {
 		return 0;
 	}
 
@@ -134,9 +130,7 @@ iscsi_login_add_sessiontype(struct iscsi_context *iscsi, struct iscsi_pdu *pdu)
 	char str[MAX_STRING_SIZE+1];
 
 	/* We only send SessionType during opneg or the first leg of secneg */
-	if ((iscsi->current_phase != ISCSI_PDU_LOGIN_CSG_OPNEG
-	&& iscsi->secneg_phase != ISCSI_LOGIN_SECNEG_PHASE_OFFER_CHAP)
-	|| iscsi->secneg_phase != ISCSI_LOGIN_SECNEG_PHASE_OFFER_CHAP) {
+	if (iscsi->secneg_phase != ISCSI_LOGIN_SECNEG_PHASE_OFFER_CHAP) {
 		return 0;
 	}
 

--- a/lib/scsi-lowlevel.c
+++ b/lib/scsi-lowlevel.c
@@ -1082,7 +1082,7 @@ scsi_maintenancein_datain_getfullsize(struct scsi_task *task)
 		case SCSI_REPORT_SUPPORTING_OPCODE:
 		case SCSI_REPORT_SUPPORTING_SERVICEACTION:
 			return 4 +
-				(task_get_uint8(task, 1) & 0x80) ? 12 : 0 +
+				((task_get_uint8(task, 1) & 0x80) ? 12 : 0) +
 				task_get_uint16(task, 2);
 		}
 		return -1;

--- a/lib/socket.c
+++ b/lib/socket.c
@@ -425,6 +425,9 @@ iscsi_tcp_disconnect(struct iscsi_context *iscsi)
 int
 iscsi_disconnect(struct iscsi_context *iscsi)
 {
+	if (!iscsi || !iscsi->drv || !iscsi->drv->disconnect)
+		return -1;
+
         return iscsi->drv->disconnect(iscsi);
 }
 

--- a/lib/sync.c
+++ b/lib/sync.c
@@ -1828,11 +1828,12 @@ void iscsi_free_discovery_data(struct iscsi_context *iscsi _U_,
 
                 while (da->portals) {
                         struct iscsi_target_portal *ponext = da->portals->next;
-                        free(discard_const(da->portals->portal));
+
+                        free(da->portals->portal);
                         free(da->portals);
                         da->portals = ponext;
                 }
-                free(discard_const(da->target_name));
+                free(da->target_name);
                 free(da);
                 da = danext;
         }

--- a/test-tool/iscsi-support.c
+++ b/test-tool/iscsi-support.c
@@ -298,10 +298,8 @@ static struct scsi_task *send_scsi_command(struct scsi_device *sdev, struct scsi
         if (sdev->iscsi_url) {
                 time_t current_time = time(NULL);
 
-                if (sdev->error_str != NULL) {
-                        free(discard_const(sdev->error_str));
-                        sdev->error_str = NULL;
-                }
+                free(sdev->error_str);
+                sdev->error_str = NULL;
                 task = iscsi_scsi_command_sync(sdev->iscsi_ctx, sdev->iscsi_lun, task, NULL);
                 if (task == NULL) {
                         sdev->error_str = strdup(iscsi_get_error(sdev->iscsi_ctx));
@@ -372,9 +370,7 @@ static struct scsi_task *send_scsi_command(struct scsi_device *sdev, struct scsi
                 if(ioctl(sdev->sgio_fd, SG_IO, &io_hdr) < 0){
                         int err = errno;
 
-                        if (sdev->error_str != NULL) {
-                                free(discard_const(sdev->error_str));
-                        }
+                        free(sdev->error_str);
                         if (asprintf(&sdev->error_str, "SG_IO ioctl failed: %s",
                                      strerror(err)) < 0)
                                 sdev->error_str = NULL;
@@ -401,18 +397,14 @@ static struct scsi_task *send_scsi_command(struct scsi_device *sdev, struct scsi
                                  task->sense.key,
                                  scsi_sense_ascq_str(task->sense.ascq),
                                  task->sense.ascq);
-                        if (sdev->error_str != NULL) {
-                                free(discard_const(sdev->error_str));
-                        }
+                        free(sdev->error_str);
                         sdev->error_str = strdup(buf);
                         return task;
                 }
 
                 if(io_hdr.status == SCSI_STATUS_RESERVATION_CONFLICT){
                         task->status = SCSI_STATUS_RESERVATION_CONFLICT;
-                        if (sdev->error_str != NULL) {
-                                free(discard_const(sdev->error_str));
-                        }
+                        free(sdev->error_str);
                         sdev->error_str = strdup("Reservation Conflict");
                         return task;
                 }
@@ -422,9 +414,7 @@ static struct scsi_task *send_scsi_command(struct scsi_device *sdev, struct scsi
                         task->sense.key = 0x0f;
                         task->sense.ascq  = 0xffff;
 
-                        if (sdev->error_str != NULL) {
-                                free(discard_const(sdev->error_str));
-                        }
+                        free(sdev->error_str);
                         sdev->error_str = strdup("SCSI masked error");
                         return NULL;
                 }
@@ -434,9 +424,7 @@ static struct scsi_task *send_scsi_command(struct scsi_device *sdev, struct scsi
                         task->sense.ascq  = 0xffff;
 
                         snprintf(buf, sizeof(buf), "SCSI host error. Status=0x%x", io_hdr.host_status);
-                        if (sdev->error_str != NULL) {
-                                free(discard_const(sdev->error_str));
-                        }
+                        free(sdev->error_str);
                         sdev->error_str = strdup(buf);
                         return task;
                 }
@@ -445,9 +433,7 @@ static struct scsi_task *send_scsi_command(struct scsi_device *sdev, struct scsi
                         task->sense.key = 0x0f;
                         task->sense.ascq  = 0xffff;
 
-                        if (sdev->error_str != NULL) {
-                                free(discard_const(sdev->error_str));
-                        }
+                        free(sdev->error_str);
                         sdev->error_str = strdup("SCSI driver error");
                         return NULL;
                 }

--- a/test-tool/iscsi-support.h
+++ b/test-tool/iscsi-support.h
@@ -53,17 +53,17 @@ extern const char *initiatorname2;
 #define EXPECT_RESERVATION_CONFLICT SCSI_STATUS_RESERVATION_CONFLICT, 0, NULL, 0
 #define EXPECT_COPY_ABORTED SCSI_STATUS_CHECK_CONDITION, SCSI_SENSE_COPY_ABORTED, copy_aborted_ascqs, 3
 
-int no_medium_ascqs[3];
-int lba_oob_ascqs[1];
-int invalid_cdb_ascqs[2];
-int param_list_len_err_ascqs[1];
-int too_many_desc_ascqs[2];
-int unsupp_desc_code_ascqs[2];
-int write_protect_ascqs[3];
-int sanitize_ascqs[1];
-int removal_ascqs[1];
-int miscompare_ascqs[1];
-int copy_aborted_ascqs[3];
+extern int no_medium_ascqs[3];
+extern int lba_oob_ascqs[1];
+extern int invalid_cdb_ascqs[2];
+extern int param_list_len_err_ascqs[1];
+extern int too_many_desc_ascqs[2];
+extern int unsupp_desc_code_ascqs[2];
+extern int write_protect_ascqs[3];
+extern int sanitize_ascqs[1];
+extern int removal_ascqs[1];
+extern int miscompare_ascqs[1];
+extern int copy_aborted_ascqs[3];
 
 extern int loglevel;
 #define LOG_SILENT  0

--- a/test-tool/iscsi-support.h
+++ b/test-tool/iscsi-support.h
@@ -30,10 +30,6 @@
 #include "iscsi.h"
 #include "scsi-lowlevel.h"
 
-#ifndef discard_const
-#define discard_const(ptr) ((void *)((intptr_t)(ptr)))
-#endif
-
 extern const char *initiatorname1;
 extern const char *initiatorname2;
 

--- a/test-tool/iscsi-test-cu.c
+++ b/test-tool/iscsi-test-cu.c
@@ -1301,6 +1301,10 @@ main(int argc, char *argv[])
         block_size = rc10->block_size;
         num_blocks = rc10->lba + 1;
         scsi_free_scsi_task(task);
+        if (block_size == 0) {
+                printf("block_size is zero - giving up.\n");
+                goto err_sds_free;
+        }
 
         rc16_task = NULL;
         readcapacity16(sd, &rc16_task, 96, EXPECT_STATUS_GOOD);
@@ -1318,6 +1322,10 @@ main(int argc, char *argv[])
                 block_size = rc16->block_length;
                 num_blocks = rc16->returned_lba + 1;
                 lbppb = 1 << rc16->lbppbe;
+                if (block_size == 0) {
+                        printf("block_size is zero - giving up.\n");
+                        goto err_sds_free;
+                }
         }
 
         /* create a really big buffer we can use in the tests */

--- a/test-tool/iscsi-test-cu.c
+++ b/test-tool/iscsi-test-cu.c
@@ -65,421 +65,421 @@ static unsigned int maxsectors;
  *
  *****************************************************************/
 static CU_TestInfo tests_compareandwrite[] = {
-        { (char *)"Simple", test_compareandwrite_simple },
-        { (char *)"DpoFua", test_compareandwrite_dpofua },
-        { (char *)"Miscompare", test_compareandwrite_miscompare },
-        { (char *)"Unwritten", test_compareandwrite_unwritten },
-        { (char *)"InvalidDataOutSize",
+        { "Simple", test_compareandwrite_simple },
+        { "DpoFua", test_compareandwrite_dpofua },
+        { "Miscompare", test_compareandwrite_miscompare },
+        { "Unwritten", test_compareandwrite_unwritten },
+        { "InvalidDataOutSize",
           test_compareandwrite_invalid_dataout_size },
         CU_TEST_INFO_NULL
 };
 
 static CU_TestInfo tests_get_lba_status[] = {
-        { (char *)"Simple", test_get_lba_status_simple },
-        { (char *)"BeyondEol", test_get_lba_status_beyond_eol },
-        { (char *)"UnmapSingle", test_get_lba_status_unmap_single },
+        { "Simple", test_get_lba_status_simple },
+        { "BeyondEol", test_get_lba_status_beyond_eol },
+        { "UnmapSingle", test_get_lba_status_unmap_single },
         CU_TEST_INFO_NULL
 };
 
 static CU_TestInfo tests_inquiry[] = {
-        { (char *)"Standard", test_inquiry_standard },
-        { (char *)"AllocLength", test_inquiry_alloc_length},
-        { (char *)"EVPD", test_inquiry_evpd},
-        { (char *)"BlockLimits", test_inquiry_block_limits},
-        { (char *)"MandatoryVPDSBC", test_inquiry_mandatory_vpd_sbc},
-        { (char *)"SupportedVPD", test_inquiry_supported_vpd},
-        { (char *)"VersionDescriptors", test_inquiry_version_descriptors},
+        { "Standard", test_inquiry_standard },
+        { "AllocLength", test_inquiry_alloc_length},
+        { "EVPD", test_inquiry_evpd},
+        { "BlockLimits", test_inquiry_block_limits},
+        { "MandatoryVPDSBC", test_inquiry_mandatory_vpd_sbc},
+        { "SupportedVPD", test_inquiry_supported_vpd},
+        { "VersionDescriptors", test_inquiry_version_descriptors},
         CU_TEST_INFO_NULL
 };
 
 static CU_TestInfo tests_mandatory[] = {
-        { (char *)"MandatorySBC", test_mandatory_sbc },
+        { "MandatorySBC", test_mandatory_sbc },
         CU_TEST_INFO_NULL
 };
 
 static CU_TestInfo tests_modesense6[] = {
-        { (char *)"AllPages", test_modesense6_all_pages },
-        { (char *)"Control", test_modesense6_control },
-        { (char *)"Control-D_SENSE", test_modesense6_control_d_sense },
-        { (char *)"Control-SWP", test_modesense6_control_swp },
-        { (char *)"Residuals", test_modesense6_residuals },
+        { "AllPages", test_modesense6_all_pages },
+        { "Control", test_modesense6_control },
+        { "Control-D_SENSE", test_modesense6_control_d_sense },
+        { "Control-SWP", test_modesense6_control_swp },
+        { "Residuals", test_modesense6_residuals },
         CU_TEST_INFO_NULL
 };
 
 static CU_TestInfo tests_nomedia[] = {
-        { (char *)"NoMediaSBC", test_nomedia_sbc },
+        { "NoMediaSBC", test_nomedia_sbc },
         CU_TEST_INFO_NULL
 };
 
 static CU_TestInfo tests_orwrite[] = {
-        { (char *)"Simple", test_orwrite_simple },
-        { (char *)"BeyondEol", test_orwrite_beyond_eol },
-        { (char *)"ZeroBlocks", test_orwrite_0blocks },
-        { (char *)"Protect", test_orwrite_wrprotect },
-        { (char *)"DpoFua", test_orwrite_dpofua },
-        { (char *)"Verify", test_orwrite_verify },
+        { "Simple", test_orwrite_simple },
+        { "BeyondEol", test_orwrite_beyond_eol },
+        { "ZeroBlocks", test_orwrite_0blocks },
+        { "Protect", test_orwrite_wrprotect },
+        { "DpoFua", test_orwrite_dpofua },
+        { "Verify", test_orwrite_verify },
         CU_TEST_INFO_NULL
 };
 
 static CU_TestInfo tests_prefetch10[] = {
-        { (char *)"Simple", test_prefetch10_simple },
-        { (char *)"BeyondEol", test_prefetch10_beyond_eol },
-        { (char *)"ZeroBlocks", test_prefetch10_0blocks },
-        { (char *)"Flags", test_prefetch10_flags },
+        { "Simple", test_prefetch10_simple },
+        { "BeyondEol", test_prefetch10_beyond_eol },
+        { "ZeroBlocks", test_prefetch10_0blocks },
+        { "Flags", test_prefetch10_flags },
         CU_TEST_INFO_NULL
 };
 
 static CU_TestInfo tests_prefetch16[] = {
-        { (char *)"Simple", test_prefetch16_simple },
-        { (char *)"BeyondEol", test_prefetch16_beyond_eol },
-        { (char *)"ZeroBlocks", test_prefetch16_0blocks },
-        { (char *)"Flags", test_prefetch16_flags },
+        { "Simple", test_prefetch16_simple },
+        { "BeyondEol", test_prefetch16_beyond_eol },
+        { "ZeroBlocks", test_prefetch16_0blocks },
+        { "Flags", test_prefetch16_flags },
         CU_TEST_INFO_NULL
 };
 
 static CU_TestInfo tests_preventallow[] = {
-        { (char *)"Simple", test_preventallow_simple },
-        { (char *)"Eject", test_preventallow_eject },
-        { (char *)"ITNexusLoss", test_preventallow_itnexus_loss },
-        { (char *)"Logout", test_preventallow_logout },
-        { (char *)"WarmReset", test_preventallow_warm_reset },
-        { (char *)"ColdReset", test_preventallow_cold_reset },
-        { (char *)"LUNReset", test_preventallow_lun_reset },
-        { (char *)"2ITNexuses", test_preventallow_2_itnexuses },
+        { "Simple", test_preventallow_simple },
+        { "Eject", test_preventallow_eject },
+        { "ITNexusLoss", test_preventallow_itnexus_loss },
+        { "Logout", test_preventallow_logout },
+        { "WarmReset", test_preventallow_warm_reset },
+        { "ColdReset", test_preventallow_cold_reset },
+        { "LUNReset", test_preventallow_lun_reset },
+        { "2ITNexuses", test_preventallow_2_itnexuses },
         CU_TEST_INFO_NULL
 };
 
 static CU_TestInfo tests_prin_read_keys[] = {
-        { (char *)"Simple", test_prin_read_keys_simple },
-        { (char *)"Truncate", test_prin_read_keys_truncate },
+        { "Simple", test_prin_read_keys_simple },
+        { "Truncate", test_prin_read_keys_truncate },
         CU_TEST_INFO_NULL
 };
 
 static CU_TestInfo tests_prin_report_caps[] = {
-        { (char *)"Simple", test_prin_report_caps_simple },
+        { "Simple", test_prin_report_caps_simple },
         CU_TEST_INFO_NULL
 };
 
 static CU_TestInfo tests_prout_register[] = {
-        { (char *)"Simple", test_prout_register_simple },
+        { "Simple", test_prout_register_simple },
         CU_TEST_INFO_NULL
 };
 
 static CU_TestInfo tests_prout_reserve[] = {
-        { (char *)"Simple",
+        { "Simple",
           test_prout_reserve_simple },
-        { (char *)"AccessEA",
+        { "AccessEA",
           test_prout_reserve_access_ea },
-        { (char *)"AccessWE",
+        { "AccessWE",
           test_prout_reserve_access_we },
-        { (char *)"AccessEARO",
+        { "AccessEARO",
           test_prout_reserve_access_earo },
-        { (char *)"AccessWERO",
+        { "AccessWERO",
           test_prout_reserve_access_wero },
-        { (char *)"AccessEAAR",
+        { "AccessEAAR",
           test_prout_reserve_access_eaar },
-        { (char *)"AccessWEAR",
+        { "AccessWEAR",
           test_prout_reserve_access_wear },
-        { (char *)"OwnershipEA",
+        { "OwnershipEA",
           test_prout_reserve_ownership_ea },
-        { (char *)"OwnershipWE",
+        { "OwnershipWE",
           test_prout_reserve_ownership_we },
-        { (char *)"OwnershipEARO",
+        { "OwnershipEARO",
           test_prout_reserve_ownership_earo },
-        { (char *)"OwnershipWERO",
+        { "OwnershipWERO",
           test_prout_reserve_ownership_wero },
-        { (char *)"OwnershipEAAR",
+        { "OwnershipEAAR",
           test_prout_reserve_ownership_eaar },
-        { (char *)"OwnershipWEAR",
+        { "OwnershipWEAR",
           test_prout_reserve_ownership_wear },
         CU_TEST_INFO_NULL
 };
 
 static CU_TestInfo tests_prout_clear[] = {
-        { (char *)"Simple",
+        { "Simple",
           test_prout_clear_simple },
         CU_TEST_INFO_NULL
 };
 
 static CU_TestInfo tests_prout_preempt[] = {
-        { (char *)"RemoveRegistration",
+        { "RemoveRegistration",
           test_prout_preempt_rm_reg },
         CU_TEST_INFO_NULL
 };
 
 static CU_TestInfo tests_prin_serviceaction_range[] = {
-        { (char *)"Range", test_prin_serviceaction_range },
+        { "Range", test_prin_serviceaction_range },
         CU_TEST_INFO_NULL
 };
 
 static CU_TestInfo tests_read6[] = {
-        { (char *)"Simple", test_read6_simple },
-        { (char *)"BeyondEol", test_read6_beyond_eol },
+        { "Simple", test_read6_simple },
+        { "BeyondEol", test_read6_beyond_eol },
         CU_TEST_INFO_NULL
 };
 
 static CU_TestInfo tests_read10[] = {
-        { (char *)"Simple", test_read10_simple },
-        { (char *)"BeyondEol", test_read10_beyond_eol },
-        { (char *)"ZeroBlocks", test_read10_0blocks },
-        { (char *)"ReadProtect", test_read10_rdprotect },
-        { (char *)"DpoFua", test_read10_dpofua },
-        { (char *)"Async", test_async_read },
+        { "Simple", test_read10_simple },
+        { "BeyondEol", test_read10_beyond_eol },
+        { "ZeroBlocks", test_read10_0blocks },
+        { "ReadProtect", test_read10_rdprotect },
+        { "DpoFua", test_read10_dpofua },
+        { "Async", test_async_read },
         CU_TEST_INFO_NULL
 };
 
 static CU_TestInfo tests_read12[] = {
-        { (char *)"Simple", test_read12_simple },
-        { (char *)"BeyondEol", test_read12_beyond_eol },
-        { (char *)"ZeroBlocks", test_read12_0blocks },
-        { (char *)"ReadProtect", test_read12_rdprotect },
-        { (char *)"DpoFua", test_read12_dpofua },
+        { "Simple", test_read12_simple },
+        { "BeyondEol", test_read12_beyond_eol },
+        { "ZeroBlocks", test_read12_0blocks },
+        { "ReadProtect", test_read12_rdprotect },
+        { "DpoFua", test_read12_dpofua },
         CU_TEST_INFO_NULL
 };
 
 static CU_TestInfo tests_read16[] = {
-        { (char *)"Simple", test_read16_simple },
-        { (char *)"BeyondEol", test_read16_beyond_eol },
-        { (char *)"ZeroBlocks", test_read16_0blocks },
-        { (char *)"ReadProtect", test_read16_rdprotect },
-        { (char *)"DpoFua", test_read16_dpofua },
+        { "Simple", test_read16_simple },
+        { "BeyondEol", test_read16_beyond_eol },
+        { "ZeroBlocks", test_read16_0blocks },
+        { "ReadProtect", test_read16_rdprotect },
+        { "DpoFua", test_read16_dpofua },
         CU_TEST_INFO_NULL
 };
 
 static CU_TestInfo tests_readcapacity10[] = {
-        { (char *)"Simple", test_readcapacity10_simple },
+        { "Simple", test_readcapacity10_simple },
         CU_TEST_INFO_NULL
 };
 
 static CU_TestInfo tests_readcapacity16[] = {
-        { (char *)"Simple", test_readcapacity16_simple },
-        { (char *)"Alloclen", test_readcapacity16_alloclen },
-        { (char *)"PI", test_readcapacity16_protection },
-        { (char *)"Support", test_readcapacity16_support },
+        { "Simple", test_readcapacity16_simple },
+        { "Alloclen", test_readcapacity16_alloclen },
+        { "PI", test_readcapacity16_protection },
+        { "Support", test_readcapacity16_support },
         CU_TEST_INFO_NULL
 };
 
 static CU_TestInfo tests_readdefectdata10[] = {
-        { (char *)"Simple", test_readdefectdata10_simple },
+        { "Simple", test_readdefectdata10_simple },
         CU_TEST_INFO_NULL
 };
 
 static CU_TestInfo tests_readdefectdata12[] = {
-        { (char *)"Simple", test_readdefectdata12_simple },
+        { "Simple", test_readdefectdata12_simple },
         CU_TEST_INFO_NULL
 };
 
 static CU_TestInfo tests_readonly[] = {
-        { (char *)"ReadOnlySBC", test_readonly_sbc },
+        { "ReadOnlySBC", test_readonly_sbc },
         CU_TEST_INFO_NULL
 };
 
 static CU_TestInfo tests_sanitize[] = {
-        { (char *)"BlockErase", test_sanitize_block_erase },
-        { (char *)"BlockEraseReserved", test_sanitize_block_erase_reserved },
-        { (char *)"CryptoErase", test_sanitize_crypto_erase },
-        { (char *)"CryptoEraseReserved", test_sanitize_crypto_erase_reserved },
-        { (char *)"ExitFailureMode", test_sanitize_exit_failure_mode },
-        { (char *)"InvalidServiceAction", test_sanitize_invalid_serviceaction },
-        { (char *)"Overwrite", test_sanitize_overwrite },
-        { (char *)"OverwriteReserved", test_sanitize_overwrite_reserved },
-        { (char *)"Readonly", test_sanitize_readonly },
-        { (char *)"Reservations", test_sanitize_reservations },
-        { (char *)"Reset", test_sanitize_reset },
+        { "BlockErase", test_sanitize_block_erase },
+        { "BlockEraseReserved", test_sanitize_block_erase_reserved },
+        { "CryptoErase", test_sanitize_crypto_erase },
+        { "CryptoEraseReserved", test_sanitize_crypto_erase_reserved },
+        { "ExitFailureMode", test_sanitize_exit_failure_mode },
+        { "InvalidServiceAction", test_sanitize_invalid_serviceaction },
+        { "Overwrite", test_sanitize_overwrite },
+        { "OverwriteReserved", test_sanitize_overwrite_reserved },
+        { "Readonly", test_sanitize_readonly },
+        { "Reservations", test_sanitize_reservations },
+        { "Reset", test_sanitize_reset },
         CU_TEST_INFO_NULL
 };
 
 static CU_TestInfo tests_extended_copy[] = {
-        { (char *)"Simple", test_extendedcopy_simple },
-        { (char *)"ParamHdr", test_extendedcopy_param },
-        { (char *)"DescrLimits", test_extendedcopy_descr_limits },
-        { (char *)"DescrType", test_extendedcopy_descr_type },
-        { (char *)"ValidTgtDescr", test_extendedcopy_validate_tgt_descr },
-        { (char *)"ValidSegDescr", test_extendedcopy_validate_seg_descr },
+        { "Simple", test_extendedcopy_simple },
+        { "ParamHdr", test_extendedcopy_param },
+        { "DescrLimits", test_extendedcopy_descr_limits },
+        { "DescrType", test_extendedcopy_descr_type },
+        { "ValidTgtDescr", test_extendedcopy_validate_tgt_descr },
+        { "ValidSegDescr", test_extendedcopy_validate_seg_descr },
         CU_TEST_INFO_NULL
 };
 
 static CU_TestInfo tests_receive_copy_results[] = {
-        { (char *)"CopyStatus", test_receive_copy_results_copy_status },
-        { (char *)"OpParams", test_receive_copy_results_op_params },
+        { "CopyStatus", test_receive_copy_results_copy_status },
+        { "OpParams", test_receive_copy_results_op_params },
         CU_TEST_INFO_NULL
 };
 
 static CU_TestInfo tests_report_supported_opcodes[] = {
-        { (char *)"Simple", test_report_supported_opcodes_simple },
-        { (char *)"OneCommand", test_report_supported_opcodes_one_command },
-        { (char *)"RCTD", test_report_supported_opcodes_rctd },
-        { (char *)"SERVACTV", test_report_supported_opcodes_servactv },
+        { "Simple", test_report_supported_opcodes_simple },
+        { "OneCommand", test_report_supported_opcodes_one_command },
+        { "RCTD", test_report_supported_opcodes_rctd },
+        { "SERVACTV", test_report_supported_opcodes_servactv },
         CU_TEST_INFO_NULL
 };
 
 static CU_TestInfo tests_reserve6[] = {
-        { (char *)"Simple", test_reserve6_simple },
-        { (char *)"2Initiators", test_reserve6_2initiators },
-        { (char *)"Logout", test_reserve6_logout },
-        { (char *)"ITNexusLoss", test_reserve6_itnexus_loss },
-        { (char *)"TargetColdReset", test_reserve6_target_cold_reset },
-        { (char *)"TargetWarmReset", test_reserve6_target_warm_reset },
-        { (char *)"LUNReset", test_reserve6_lun_reset },
+        { "Simple", test_reserve6_simple },
+        { "2Initiators", test_reserve6_2initiators },
+        { "Logout", test_reserve6_logout },
+        { "ITNexusLoss", test_reserve6_itnexus_loss },
+        { "TargetColdReset", test_reserve6_target_cold_reset },
+        { "TargetWarmReset", test_reserve6_target_warm_reset },
+        { "LUNReset", test_reserve6_lun_reset },
         CU_TEST_INFO_NULL
 };
 
 static CU_TestInfo tests_testunitready[] = {
-        { (char *)"Simple", test_testunitready_simple },
+        { "Simple", test_testunitready_simple },
         CU_TEST_INFO_NULL
 };
 
 static CU_TestInfo tests_startstopunit[] = {
-        { (char *)"Simple", test_startstopunit_simple },
-        { (char *)"PwrCnd", test_startstopunit_pwrcnd },
-        { (char *)"NoLoej", test_startstopunit_noloej },
+        { "Simple", test_startstopunit_simple },
+        { "PwrCnd", test_startstopunit_pwrcnd },
+        { "NoLoej", test_startstopunit_noloej },
         CU_TEST_INFO_NULL
 };
 
 static CU_TestInfo tests_unmap[] = {
-        { (char *)"Simple", test_unmap_simple },
-        { (char *)"VPD", test_unmap_vpd },
-        { (char *)"ZeroBlocks", test_unmap_0blocks },
+        { "Simple", test_unmap_simple },
+        { "VPD", test_unmap_vpd },
+        { "ZeroBlocks", test_unmap_0blocks },
         CU_TEST_INFO_NULL
 };
 
 static CU_TestInfo tests_verify10[] = {
-        { (char *)"Simple", test_verify10_simple },
-        { (char *)"BeyondEol", test_verify10_beyond_eol },
-        { (char *)"ZeroBlocks", test_verify10_0blocks },
-        { (char *)"VerifyProtect", test_verify10_vrprotect },
-        { (char *)"Flags", test_verify10_flags },
-        { (char *)"Dpo", test_verify10_dpo },
-        { (char *)"Mismatch", test_verify10_mismatch },
-        { (char *)"MismatchNoCmp", test_verify10_mismatch_no_cmp },
+        { "Simple", test_verify10_simple },
+        { "BeyondEol", test_verify10_beyond_eol },
+        { "ZeroBlocks", test_verify10_0blocks },
+        { "VerifyProtect", test_verify10_vrprotect },
+        { "Flags", test_verify10_flags },
+        { "Dpo", test_verify10_dpo },
+        { "Mismatch", test_verify10_mismatch },
+        { "MismatchNoCmp", test_verify10_mismatch_no_cmp },
         CU_TEST_INFO_NULL
 };
 
 static CU_TestInfo tests_verify12[] = {
-        { (char *)"Simple", test_verify12_simple },
-        { (char *)"BeyondEol", test_verify12_beyond_eol },
-        { (char *)"ZeroBlocks", test_verify12_0blocks },
-        { (char *)"VerifyProtect", test_verify12_vrprotect },
-        { (char *)"Flags", test_verify12_flags },
-        { (char *)"Dpo", test_verify12_dpo },
-        { (char *)"Mismatch", test_verify12_mismatch },
-        { (char *)"MismatchNoCmp", test_verify12_mismatch_no_cmp },
+        { "Simple", test_verify12_simple },
+        { "BeyondEol", test_verify12_beyond_eol },
+        { "ZeroBlocks", test_verify12_0blocks },
+        { "VerifyProtect", test_verify12_vrprotect },
+        { "Flags", test_verify12_flags },
+        { "Dpo", test_verify12_dpo },
+        { "Mismatch", test_verify12_mismatch },
+        { "MismatchNoCmp", test_verify12_mismatch_no_cmp },
         CU_TEST_INFO_NULL
 };
 
 static CU_TestInfo tests_verify16[] = {
-        { (char *)"Simple", test_verify16_simple },
-        { (char *)"BeyondEol", test_verify16_beyond_eol },
-        { (char *)"ZeroBlocks", test_verify16_0blocks },
-        { (char *)"VerifyProtect", test_verify16_vrprotect },
-        { (char *)"Flags", test_verify16_flags },
-        { (char *)"Dpo", test_verify16_dpo },
-        { (char *)"Mismatch", test_verify16_mismatch },
-        { (char *)"MismatchNoCmp", test_verify16_mismatch_no_cmp },
+        { "Simple", test_verify16_simple },
+        { "BeyondEol", test_verify16_beyond_eol },
+        { "ZeroBlocks", test_verify16_0blocks },
+        { "VerifyProtect", test_verify16_vrprotect },
+        { "Flags", test_verify16_flags },
+        { "Dpo", test_verify16_dpo },
+        { "Mismatch", test_verify16_mismatch },
+        { "MismatchNoCmp", test_verify16_mismatch_no_cmp },
         CU_TEST_INFO_NULL
 };
 
 static CU_TestInfo tests_write10[] = {
-        { (char *)"Simple", test_write10_simple },
-        { (char *)"BeyondEol", test_write10_beyond_eol },
-        { (char *)"ZeroBlocks", test_write10_0blocks },
-        { (char *)"WriteProtect", test_write10_wrprotect },
-        { (char *)"DpoFua", test_write10_dpofua },
-        { (char *)"Async", test_async_write },
+        { "Simple", test_write10_simple },
+        { "BeyondEol", test_write10_beyond_eol },
+        { "ZeroBlocks", test_write10_0blocks },
+        { "WriteProtect", test_write10_wrprotect },
+        { "DpoFua", test_write10_dpofua },
+        { "Async", test_async_write },
         CU_TEST_INFO_NULL
 };
 
 static CU_TestInfo tests_write12[] = {
-        { (char *)"Simple", test_write12_simple },
-        { (char *)"BeyondEol", test_write12_beyond_eol },
-        { (char *)"ZeroBlocks", test_write12_0blocks },
-        { (char *)"WriteProtect", test_write12_wrprotect },
-        { (char *)"DpoFua", test_write12_dpofua },
+        { "Simple", test_write12_simple },
+        { "BeyondEol", test_write12_beyond_eol },
+        { "ZeroBlocks", test_write12_0blocks },
+        { "WriteProtect", test_write12_wrprotect },
+        { "DpoFua", test_write12_dpofua },
         CU_TEST_INFO_NULL
 };
 
 static CU_TestInfo tests_write16[] = {
-        { (char *)"Simple", test_write16_simple },
-        { (char *)"BeyondEol", test_write16_beyond_eol },
-        { (char *)"ZeroBlocks", test_write16_0blocks },
-        { (char *)"WriteProtect", test_write16_wrprotect },
-        { (char *)"DpoFua", test_write16_dpofua },
+        { "Simple", test_write16_simple },
+        { "BeyondEol", test_write16_beyond_eol },
+        { "ZeroBlocks", test_write16_0blocks },
+        { "WriteProtect", test_write16_wrprotect },
+        { "DpoFua", test_write16_dpofua },
         CU_TEST_INFO_NULL
 };
 
 static CU_TestInfo tests_writeatomic16[] = {
-        { (char *)"Simple", test_writeatomic16_simple },
-        { (char *)"BeyondEol", test_writeatomic16_beyond_eol },
-        { (char *)"ZeroBlocks", test_writeatomic16_0blocks },
-        { (char *)"WriteProtect", test_writeatomic16_wrprotect },
-        { (char *)"DpoFua", test_writeatomic16_dpofua },
-        { (char *)"VPD", test_writeatomic16_vpd },
+        { "Simple", test_writeatomic16_simple },
+        { "BeyondEol", test_writeatomic16_beyond_eol },
+        { "ZeroBlocks", test_writeatomic16_0blocks },
+        { "WriteProtect", test_writeatomic16_wrprotect },
+        { "DpoFua", test_writeatomic16_dpofua },
+        { "VPD", test_writeatomic16_vpd },
         CU_TEST_INFO_NULL
 };
 
 static CU_TestInfo tests_writesame10[] = {
-        { (char *)"Simple", test_writesame10_simple },
-        { (char *)"BeyondEol", test_writesame10_beyond_eol },
-        { (char *)"ZeroBlocks", test_writesame10_0blocks },
-        { (char *)"WriteProtect", test_writesame10_wrprotect },
-        { (char *)"Unmap", test_writesame10_unmap },
-        { (char *)"UnmapUnaligned", test_writesame10_unmap_unaligned },
-        { (char *)"UnmapUntilEnd", test_writesame10_unmap_until_end },
-        { (char *)"UnmapVPD", test_writesame10_unmap_vpd },
-        { (char *)"Check", test_writesame10_check },
-        { (char *)"InvalidDataOutSize", test_writesame10_invalid_dataout_size },
+        { "Simple", test_writesame10_simple },
+        { "BeyondEol", test_writesame10_beyond_eol },
+        { "ZeroBlocks", test_writesame10_0blocks },
+        { "WriteProtect", test_writesame10_wrprotect },
+        { "Unmap", test_writesame10_unmap },
+        { "UnmapUnaligned", test_writesame10_unmap_unaligned },
+        { "UnmapUntilEnd", test_writesame10_unmap_until_end },
+        { "UnmapVPD", test_writesame10_unmap_vpd },
+        { "Check", test_writesame10_check },
+        { "InvalidDataOutSize", test_writesame10_invalid_dataout_size },
         CU_TEST_INFO_NULL
 };
 
 static CU_TestInfo tests_writesame16[] = {
-        { (char *)"Simple", test_writesame16_simple },
-        { (char *)"BeyondEol", test_writesame16_beyond_eol },
-        { (char *)"ZeroBlocks", test_writesame16_0blocks },
-        { (char *)"WriteProtect", test_writesame16_wrprotect },
-        { (char *)"Unmap", test_writesame16_unmap },
-        { (char *)"UnmapUnaligned", test_writesame16_unmap_unaligned },
-        { (char *)"UnmapUntilEnd", test_writesame16_unmap_until_end },
-        { (char *)"UnmapVPD", test_writesame16_unmap_vpd },
-        { (char *)"Check", test_writesame16_check },
-        { (char *)"InvalidDataOutSize", test_writesame16_invalid_dataout_size },
+        { "Simple", test_writesame16_simple },
+        { "BeyondEol", test_writesame16_beyond_eol },
+        { "ZeroBlocks", test_writesame16_0blocks },
+        { "WriteProtect", test_writesame16_wrprotect },
+        { "Unmap", test_writesame16_unmap },
+        { "UnmapUnaligned", test_writesame16_unmap_unaligned },
+        { "UnmapUntilEnd", test_writesame16_unmap_until_end },
+        { "UnmapVPD", test_writesame16_unmap_vpd },
+        { "Check", test_writesame16_check },
+        { "InvalidDataOutSize", test_writesame16_invalid_dataout_size },
         CU_TEST_INFO_NULL
 };
 
 static CU_TestInfo tests_writeverify10[] = {
-        { (char *)"Simple", test_writeverify10_simple },
-        { (char *)"BeyondEol", test_writeverify10_beyond_eol },
-        { (char *)"ZeroBlocks", test_writeverify10_0blocks },
-        { (char *)"WriteProtect", test_writeverify10_wrprotect },
-        { (char *)"Flags", test_writeverify10_flags },
-        { (char *)"Dpo", test_writeverify10_dpo },
+        { "Simple", test_writeverify10_simple },
+        { "BeyondEol", test_writeverify10_beyond_eol },
+        { "ZeroBlocks", test_writeverify10_0blocks },
+        { "WriteProtect", test_writeverify10_wrprotect },
+        { "Flags", test_writeverify10_flags },
+        { "Dpo", test_writeverify10_dpo },
         CU_TEST_INFO_NULL
 };
 
 static CU_TestInfo tests_writeverify12[] = {
-        { (char *)"Simple", test_writeverify12_simple },
-        { (char *)"BeyondEol", test_writeverify12_beyond_eol },
-        { (char *)"ZeroBlocks", test_writeverify12_0blocks },
-        { (char *)"WriteProtect", test_writeverify12_wrprotect },
-        { (char *)"Flags", test_writeverify12_flags },
-        { (char *)"Dpo", test_writeverify12_dpo },
+        { "Simple", test_writeverify12_simple },
+        { "BeyondEol", test_writeverify12_beyond_eol },
+        { "ZeroBlocks", test_writeverify12_0blocks },
+        { "WriteProtect", test_writeverify12_wrprotect },
+        { "Flags", test_writeverify12_flags },
+        { "Dpo", test_writeverify12_dpo },
         CU_TEST_INFO_NULL
 };
 
 static CU_TestInfo tests_writeverify16[] = {
-        { (char *)"Simple", test_writeverify16_simple },
-        { (char *)"BeyondEol", test_writeverify16_beyond_eol },
-        { (char *)"ZeroBlocks", test_writeverify16_0blocks },
-        { (char *)"WriteProtect", test_writeverify16_wrprotect },
-        { (char *)"Flags", test_writeverify16_flags },
-        { (char *)"Dpo", test_writeverify16_dpo },
+        { "Simple", test_writeverify16_simple },
+        { "BeyondEol", test_writeverify16_beyond_eol },
+        { "ZeroBlocks", test_writeverify16_0blocks },
+        { "WriteProtect", test_writeverify16_wrprotect },
+        { "Flags", test_writeverify16_flags },
+        { "Dpo", test_writeverify16_dpo },
         CU_TEST_INFO_NULL
 };
 
 static CU_TestInfo tests_multipathio[] = {
-        { (char *)"Simple", test_multipathio_simple },
-        { (char *)"Reset", test_multipathio_reset },
-        { (char *)"CompareAndWrite", test_multipathio_compareandwrite },
-        { (char *)"CompareAndWriteAsync", test_mpio_async_caw },
+        { "Simple", test_multipathio_simple },
+        { "Reset", test_multipathio_reset },
+        { "CompareAndWrite", test_multipathio_compareandwrite },
+        { "CompareAndWriteAsync", test_mpio_async_caw },
         CU_TEST_INFO_NULL
 };
 
@@ -548,50 +548,50 @@ static libiscsi_suite_info scsi_suites[] = {
 };
 
 static CU_TestInfo tests_iscsi_cmdsn[] = {
-        { (char *)"iSCSICmdSnTooHigh", test_iscsi_cmdsn_toohigh },
-        { (char *)"iSCSICmdSnTooLow", test_iscsi_cmdsn_toolow },
+        { "iSCSICmdSnTooHigh", test_iscsi_cmdsn_toohigh },
+        { "iSCSICmdSnTooLow", test_iscsi_cmdsn_toolow },
         CU_TEST_INFO_NULL
 };
 
 static CU_TestInfo tests_iscsi_datasn[] = {
-        { (char *)"iSCSIDataSnInvalid", test_iscsi_datasn_invalid },
+        { "iSCSIDataSnInvalid", test_iscsi_datasn_invalid },
         CU_TEST_INFO_NULL
 };
 
 static CU_TestInfo tests_iscsi_sendtargets[] = {
-        { (char *)"Simple", test_iscsi_sendtargets_simple },
-        { (char *)"Invalid", test_iscsi_sendtargets_invalid },
+        { "Simple", test_iscsi_sendtargets_simple },
+        { "Invalid", test_iscsi_sendtargets_invalid },
         CU_TEST_INFO_NULL
 };
 
 static CU_TestInfo tests_iscsi_nop[] = {
-        { (char *)"Simple", test_iscsi_nop_simple },
+        { "Simple", test_iscsi_nop_simple },
         CU_TEST_INFO_NULL
 };
 
 static CU_TestInfo tests_iscsi_chap[] = {
-        { (char *)"Simple", test_iscsi_chap_simple },
-        { (char *)"Invalid", test_iscsi_chap_invalid },
+        { "Simple", test_iscsi_chap_simple },
+        { "Invalid", test_iscsi_chap_invalid },
         CU_TEST_INFO_NULL
 };
 
 static CU_TestInfo tests_iscsi_residuals[] = {
-        { (char *)"Read10Invalid", test_read10_invalid },
-        { (char *)"Read10Residuals", test_read10_residuals },
-        { (char *)"Read12Residuals", test_read12_residuals },
-        { (char *)"Read16Residuals", test_read16_residuals },
-        { (char *)"Write10Residuals", test_write10_residuals },
-        { (char *)"Write12Residuals", test_write12_residuals },
-        { (char *)"Write16Residuals", test_write16_residuals },
-        { (char *)"WriteVerify10Residuals", test_writeverify10_residuals },
-        { (char *)"WriteVerify12Residuals", test_writeverify12_residuals },
-        { (char *)"WriteVerify16Residuals", test_writeverify16_residuals },
+        { "Read10Invalid", test_read10_invalid },
+        { "Read10Residuals", test_read10_residuals },
+        { "Read12Residuals", test_read12_residuals },
+        { "Read16Residuals", test_read16_residuals },
+        { "Write10Residuals", test_write10_residuals },
+        { "Write12Residuals", test_write12_residuals },
+        { "Write16Residuals", test_write16_residuals },
+        { "WriteVerify10Residuals", test_writeverify10_residuals },
+        { "WriteVerify12Residuals", test_writeverify12_residuals },
+        { "WriteVerify16Residuals", test_writeverify16_residuals },
         CU_TEST_INFO_NULL
 };
 
 static CU_TestInfo tests_iscsi_tmf[] = {
-        { (char *)"AbortTaskSimpleAsync", test_async_abort_simple },
-        { (char *)"LUNResetSimpleAsync", test_async_lu_reset_simple },
+        { "AbortTaskSimpleAsync", test_async_abort_simple },
+        { "LUNResetSimpleAsync", test_async_lu_reset_simple },
         CU_TEST_INFO_NULL
 };
 

--- a/test-tool/iscsi-test-cu.c
+++ b/test-tool/iscsi-test-cu.c
@@ -730,6 +730,7 @@ static struct test_family families[] = {
  */
 struct scsi_task *task;
 unsigned char *read_write_buf;
+int (*orig_queue_pdu)(struct iscsi_context *iscsi, struct iscsi_pdu *pdu);
 
 static void
 print_usage(void)
@@ -825,11 +826,14 @@ test_setup(void)
 {
         task = NULL;
         read_write_buf = NULL;
+        orig_queue_pdu = sd->iscsi_ctx ? sd->iscsi_ctx->drv->queue_pdu : NULL;
 }
 
 void
 test_teardown(void)
 {
+        if (sd->iscsi_ctx)
+                sd->iscsi_ctx->drv->queue_pdu = orig_queue_pdu;
         free(read_write_buf);
         read_write_buf = NULL;
         scsi_free_scsi_task(task);

--- a/test-tool/iscsi-test-cu.h
+++ b/test-tool/iscsi-test-cu.h
@@ -35,6 +35,8 @@
 /* globals between setup, tests, and teardown */
 extern struct scsi_task *task;
 extern unsigned char *read_write_buf;
+extern int (*orig_queue_pdu)(struct iscsi_context *iscsi,
+                             struct iscsi_pdu *pdu);
 
 #ifndef HAVE_CU_SUITEINFO_PSETUPFUNC
 /* libcunit version 1 */

--- a/test-tool/test_compareandwrite_invalid_dataout_size.c
+++ b/test-tool/test_compareandwrite_invalid_dataout_size.c
@@ -27,7 +27,6 @@
 
 
 static int new_tl;
-static struct iscsi_transport iscsi_drv_orig;
 
 static int my_iscsi_queue_pdu(struct iscsi_context *iscsi, struct iscsi_pdu *pdu)
 {
@@ -45,7 +44,7 @@ static int my_iscsi_queue_pdu(struct iscsi_context *iscsi, struct iscsi_pdu *pdu
                 break;
         }
 out:
-        return iscsi_drv_orig.queue_pdu(iscsi, pdu);
+        return orig_queue_pdu(iscsi, pdu);
 }
 
 void
@@ -58,7 +57,6 @@ test_compareandwrite_invalid_dataout_size(void)
         CHECK_FOR_ISCSI(sd);
 
         /* override transport queue_pdu callback for PDU manipulation */
-        iscsi_drv_orig = *sd->iscsi_ctx->drv;
         sd->iscsi_ctx->drv->queue_pdu = my_iscsi_queue_pdu;
 
         logging(LOG_VERBOSE, LOG_BLANK_LINE);
@@ -86,7 +84,4 @@ test_compareandwrite_invalid_dataout_size(void)
                         scratch, 4 * block_size,
                         block_size, 0, 0, 0, 0,
                         EXPECT_STATUS_GENERIC_BAD);
-
-        /* restore transport callbacks */
-        *(sd->iscsi_ctx->drv) = iscsi_drv_orig;
 }

--- a/test-tool/test_iscsi_cmdsn_toohigh.c
+++ b/test-tool/test_iscsi_cmdsn_toohigh.c
@@ -25,7 +25,6 @@
 #include "iscsi-test-cu.h"
 
 static int change_cmdsn;
-static struct iscsi_transport iscsi_drv_orig;
 
 static int my_iscsi_queue_pdu(struct iscsi_context *iscsi, struct iscsi_pdu *pdu)
 {
@@ -44,7 +43,7 @@ static int my_iscsi_queue_pdu(struct iscsi_context *iscsi, struct iscsi_pdu *pdu
         }
 
         change_cmdsn = 0;
-        return iscsi_drv_orig.queue_pdu(iscsi, pdu);
+        return orig_queue_pdu(iscsi, pdu);
 }
 
 void test_iscsi_cmdsn_toohigh(void)
@@ -63,7 +62,6 @@ void test_iscsi_cmdsn_toohigh(void)
         sd->iscsi_ctx->use_immediate_data = ISCSI_IMMEDIATE_DATA_NO;
         sd->iscsi_ctx->target_max_recv_data_segment_length = block_size;
         /* override transport queue_pdu callback for PDU manipulation */
-        iscsi_drv_orig = *sd->iscsi_ctx->drv;
         sd->iscsi_ctx->drv->queue_pdu = my_iscsi_queue_pdu;
         change_cmdsn = 1;
         /* we don't want autoreconnect since some targets will incorrectly
@@ -85,7 +83,4 @@ void test_iscsi_cmdsn_toohigh(void)
         logging(LOG_VERBOSE, "Send a TESTUNITREADY with CMDSN == EXPCMDSN. should work again");
         TESTUNITREADY(sd,
                       EXPECT_STATUS_GOOD);
-
-        /* restore transport callbacks */
-        *(sd->iscsi_ctx->drv) = iscsi_drv_orig;
 }

--- a/test-tool/test_iscsi_cmdsn_toolow.c
+++ b/test-tool/test_iscsi_cmdsn_toolow.c
@@ -25,7 +25,6 @@
 #include "iscsi-test-cu.h"
 
 static int change_cmdsn;
-static struct iscsi_transport iscsi_drv_orig;
 
 static int my_iscsi_queue_pdu(struct iscsi_context *iscsi, struct iscsi_pdu *pdu)
 {
@@ -44,7 +43,7 @@ static int my_iscsi_queue_pdu(struct iscsi_context *iscsi, struct iscsi_pdu *pdu
         }
 
         change_cmdsn = 0;
-        return iscsi_drv_orig.queue_pdu(iscsi, pdu);
+        return orig_queue_pdu(iscsi, pdu);
 }
 
 void test_iscsi_cmdsn_toolow(void)
@@ -63,7 +62,6 @@ void test_iscsi_cmdsn_toolow(void)
         sd->iscsi_ctx->use_immediate_data = ISCSI_IMMEDIATE_DATA_NO;
         sd->iscsi_ctx->target_max_recv_data_segment_length = block_size;
         /* override transport queue_pdu callback for PDU manipulation */
-        iscsi_drv_orig = *sd->iscsi_ctx->drv;
         sd->iscsi_ctx->drv->queue_pdu = my_iscsi_queue_pdu;
         change_cmdsn = 1;
         /* we don't want autoreconnect since some targets will incorrectly
@@ -85,7 +83,4 @@ void test_iscsi_cmdsn_toolow(void)
         logging(LOG_VERBOSE, "Send a TESTUNITREADY with CMDSN == EXPCMDSN. should work again");
         TESTUNITREADY(sd,
                       EXPECT_STATUS_GOOD);
-
-        /* restore transport callbacks */
-        *(sd->iscsi_ctx->drv) = iscsi_drv_orig;
 }

--- a/test-tool/test_iscsi_sendtargets.c
+++ b/test-tool/test_iscsi_sendtargets.c
@@ -141,7 +141,7 @@ test_iscsi_text_req_queue(struct iscsi_context *iscsi,
         iscsi_pdu_set_pduflags(pdu, ISCSI_PDU_TEXT_FINAL);
         iscsi_pdu_set_ttt(pdu, 0xffffffff);
 
-        ret = iscsi_pdu_add_data(iscsi, pdu, (unsigned char *)kv_data,
+        ret = iscsi_pdu_add_data(iscsi, pdu, (const unsigned char *)kv_data,
                                  strlen(kv_data) + 1);
         CU_ASSERT_EQUAL_FATAL(ret, 0);
 

--- a/test-tool/test_sanitize_block_erase_reserved.c
+++ b/test-tool/test_sanitize_block_erase_reserved.c
@@ -25,7 +25,6 @@
 #include "iscsi-test-cu.h"
 
 static int change_num;
-static struct iscsi_transport iscsi_drv_orig;
 
 static int my_iscsi_queue_pdu(struct iscsi_context *iscsi, struct iscsi_pdu *pdu)
 {
@@ -45,7 +44,7 @@ static int my_iscsi_queue_pdu(struct iscsi_context *iscsi, struct iscsi_pdu *pdu
         }
 
         change_num = 0;
-        return iscsi_drv_orig.queue_pdu(iscsi, pdu);
+        return orig_queue_pdu(iscsi, pdu);
 }
 
 void test_sanitize_block_erase_reserved(void)
@@ -60,7 +59,6 @@ void test_sanitize_block_erase_reserved(void)
         CHECK_FOR_ISCSI(sd);
 
         /* override transport queue_pdu callback for PDU manipulation */
-        iscsi_drv_orig = *sd->iscsi_ctx->drv;
         sd->iscsi_ctx->drv->queue_pdu = my_iscsi_queue_pdu;
 
         logging(LOG_VERBOSE, "Send SANITIZE command with the reserved "
@@ -77,7 +75,4 @@ void test_sanitize_block_erase_reserved(void)
                 SANITIZE(sd, 0, 0, SCSI_SANITIZE_BLOCK_ERASE, 0, NULL,
                          EXPECT_INVALID_FIELD_IN_CDB);
         }
-
-        /* restore transport callbacks */
-        *(sd->iscsi_ctx->drv) = iscsi_drv_orig;
 }

--- a/test-tool/test_sanitize_crypto_erase_reserved.c
+++ b/test-tool/test_sanitize_crypto_erase_reserved.c
@@ -25,7 +25,6 @@
 #include "iscsi-test-cu.h"
 
 static int change_num;
-static struct iscsi_transport iscsi_drv_orig;
 
 static int my_iscsi_queue_pdu(struct iscsi_context *iscsi, struct iscsi_pdu *pdu)
 {
@@ -45,7 +44,7 @@ static int my_iscsi_queue_pdu(struct iscsi_context *iscsi, struct iscsi_pdu *pdu
         }
 
         change_num = 0;
-        return iscsi_drv_orig.queue_pdu(iscsi, pdu);
+        return orig_queue_pdu(iscsi, pdu);
 }
 
 void test_sanitize_crypto_erase_reserved(void)
@@ -60,7 +59,6 @@ void test_sanitize_crypto_erase_reserved(void)
         CHECK_FOR_ISCSI(sd);
 
         /* override transport queue_pdu callback for PDU manipulation */
-        iscsi_drv_orig = *sd->iscsi_ctx->drv;
         sd->iscsi_ctx->drv->queue_pdu = my_iscsi_queue_pdu;
 
         logging(LOG_VERBOSE, "Send SANITIZE command with the reserved "
@@ -77,7 +75,4 @@ void test_sanitize_crypto_erase_reserved(void)
                 SANITIZE(sd, 0, 0, SCSI_SANITIZE_CRYPTO_ERASE, 0, NULL,
                          EXPECT_INVALID_FIELD_IN_CDB);
         }
-
-        /* restore transport callbacks */
-        *(sd->iscsi_ctx->drv) = iscsi_drv_orig;
 }

--- a/test-tool/test_sanitize_overwrite_reserved.c
+++ b/test-tool/test_sanitize_overwrite_reserved.c
@@ -26,7 +26,6 @@
 #include "iscsi-test-cu.h"
 
 static int change_num;
-static struct iscsi_transport iscsi_drv_orig;
 
 static int my_iscsi_queue_pdu(struct iscsi_context *iscsi, struct iscsi_pdu *pdu)
 {
@@ -46,7 +45,7 @@ static int my_iscsi_queue_pdu(struct iscsi_context *iscsi, struct iscsi_pdu *pdu
         }
 
         change_num = 0;
-        return iscsi_drv_orig.queue_pdu(iscsi, pdu);
+        return orig_queue_pdu(iscsi, pdu);
 }
 
 void test_sanitize_overwrite_reserved(void)
@@ -71,7 +70,6 @@ void test_sanitize_overwrite_reserved(void)
         CHECK_FOR_ISCSI(sd);
 
         /* override transport queue_pdu callback for PDU manipulation */
-        iscsi_drv_orig = *sd->iscsi_ctx->drv;
         sd->iscsi_ctx->drv->queue_pdu = my_iscsi_queue_pdu;
 
         logging(LOG_VERBOSE, "Send SANITIZE command with the reserved "
@@ -88,7 +86,4 @@ void test_sanitize_overwrite_reserved(void)
                 SANITIZE(sd, 0, 0, SCSI_SANITIZE_OVERWRITE, data.size, &data,
                          EXPECT_INVALID_FIELD_IN_CDB);
         }
-
-        /* restore transport callbacks */
-        *(sd->iscsi_ctx->drv) = iscsi_drv_orig;
 }

--- a/test-tool/test_writesame10_unmap_until_end.c
+++ b/test-tool/test_writesame10_unmap_until_end.c
@@ -53,9 +53,11 @@ test_writesame10_unmap_until_end(void)
                         i * block_size, block_size, 0, 0, 0, 0, 0, scratch,
                         EXPECT_STATUS_GOOD);
 
+                // write 0-buffer to entire range.
+                memset(scratch, 0, block_size * i);
                 logging(LOG_VERBOSE, "Unmap %d blocks using WRITESAME10", i);
                 WRITESAME10(sd, num_blocks - i,
-                            block_size, 0, 0, 1, 0, 0, scratch,
+                            block_size, i, 0, 0, 0, 0, scratch,
                             EXPECT_STATUS_GOOD);
 
                 if (rc16->lbprz) {

--- a/test-tool/test_writesame10_unmap_until_end.c
+++ b/test-tool/test_writesame10_unmap_until_end.c
@@ -57,7 +57,7 @@ test_writesame10_unmap_until_end(void)
                 memset(scratch, 0, block_size * i);
                 logging(LOG_VERBOSE, "Unmap %d blocks using WRITESAME10", i);
                 WRITESAME10(sd, num_blocks - i,
-                            block_size, i, 0, 0, 0, 0, scratch,
+                            block_size, i, 0, 1, 0, 0, scratch,
                             EXPECT_STATUS_GOOD);
 
                 if (rc16->lbprz) {

--- a/test-tool/test_writesame16_unmap_until_end.c
+++ b/test-tool/test_writesame16_unmap_until_end.c
@@ -58,7 +58,7 @@ test_writesame16_unmap_until_end(void)
                 logging(LOG_VERBOSE, "Unmap %d blocks using WRITESAME16", i);
                 memset(scratch, 0, block_size);
                 WRITESAME16(sd, num_blocks - i,
-                            block_size, 0, 0, 1, 0, 0, scratch,
+                            block_size, i, 0, 1, 0, 0, scratch,
                             EXPECT_STATUS_GOOD);
 
                 if (rc16->lbprz) {

--- a/tests/prog_header_digest.c
+++ b/tests/prog_header_digest.c
@@ -37,10 +37,6 @@
 #include "iscsi-private.h"
 #include "scsi-lowlevel.h"
 
-#ifndef discard_const
-#define discard_const(ptr) ((void *)((intptr_t)(ptr)))
-#endif
-
 const char *initiator = "iqn.2007-10.com.github:sahlberg:libiscsi:prog-header-digest";
 
 struct client_state {
@@ -136,7 +132,7 @@ int main(int argc, char *argv[])
 	struct iscsi_context *iscsi;
 	struct iscsi_url *iscsi_url = NULL;
 	struct client_state state;
-	const char *url = NULL;
+	char *url = NULL;
 	int c;
 	static int show_help = 0, show_usage = 0, debug = 0;
 
@@ -210,10 +206,8 @@ int main(int argc, char *argv[])
 	}
 
 	iscsi_url = iscsi_parse_full_url(iscsi, url);
-	
-	if (url) {
-		free(discard_const(url));
-	}
+
+        free(url);
 
 	if (iscsi_url == NULL) {
 		fprintf(stderr, "Failed to parse URL: %s\n", 

--- a/tests/prog_noop_reply.c
+++ b/tests/prog_noop_reply.c
@@ -37,10 +37,6 @@
 #include "iscsi-private.h"
 #include "scsi-lowlevel.h"
 
-#ifndef discard_const
-#define discard_const(ptr) ((void *)((intptr_t)(ptr)))
-#endif
-
 const char *initiator = "iqn.2007-10.com.github:sahlberg:libiscsi:prog-noop-reply";
 
 struct client_state {
@@ -136,7 +132,7 @@ int main(int argc, char *argv[])
 	struct iscsi_context *iscsi;
 	struct iscsi_url *iscsi_url = NULL;
 	struct client_state state;
-	const char *url = NULL;
+	char *url = NULL;
 	int c;
 	static int show_help = 0, show_usage = 0, debug = 0;
 
@@ -210,10 +206,8 @@ int main(int argc, char *argv[])
 	}
 
 	iscsi_url = iscsi_parse_full_url(iscsi, url);
-	
-	if (url) {
-		free(discard_const(url));
-	}
+
+        free(url);
 
 	if (iscsi_url == NULL) {
 		fprintf(stderr, "Failed to parse URL: %s\n", 

--- a/tests/prog_read_all_pdus.c
+++ b/tests/prog_read_all_pdus.c
@@ -34,10 +34,6 @@
 #include "iscsi.h"
 #include "scsi-lowlevel.h"
 
-#ifndef discard_const
-#define discard_const(ptr) ((void *)((intptr_t)(ptr)))
-#endif
-
 const char *initiator = "iqn.2007-10.com.github:sahlberg:libiscsi:prog-readwrite-iov";
 
 void print_usage(void)
@@ -84,7 +80,7 @@ int main(int argc, char *argv[])
 {
 	struct iscsi_context *iscsi;
 	struct iscsi_url *iscsi_url = NULL;
-	const char *url = NULL;
+	char *url = NULL;
 	static int show_help = 0, show_usage = 0, debug = 0;
         int c, i, count;
 
@@ -156,10 +152,8 @@ int main(int argc, char *argv[])
 	}
 
 	iscsi_url = iscsi_parse_full_url(iscsi, url);
-	
-	if (url) {
-		free(discard_const(url));
-	}
+
+        free(url);
 
 	if (iscsi_url == NULL) {
 		fprintf(stderr, "Failed to parse URL: %s\n", 

--- a/tests/prog_readwrite_iov.c
+++ b/tests/prog_readwrite_iov.c
@@ -34,10 +34,6 @@
 #include "iscsi.h"
 #include "scsi-lowlevel.h"
 
-#ifndef discard_const
-#define discard_const(ptr) ((void *)((intptr_t)(ptr)))
-#endif
-
 const char *initiator = "iqn.2007-10.com.github:sahlberg:libiscsi:prog-readwrite-iov";
 
 void print_usage(void)
@@ -75,7 +71,7 @@ int main(int argc, char *argv[])
 {
 	struct iscsi_context *iscsi;
 	struct iscsi_url *iscsi_url = NULL;
-	const char *url = NULL;
+	char *url = NULL;
 	static int show_help = 0, show_usage = 0, debug = 0;
         struct scsi_task *task;
         struct scsi_iovec iov[4];
@@ -152,10 +148,8 @@ int main(int argc, char *argv[])
 	}
 
 	iscsi_url = iscsi_parse_full_url(iscsi, url);
-	
-	if (url) {
-		free(discard_const(url));
-	}
+
+        free(url);
 
 	if (iscsi_url == NULL) {
 		fprintf(stderr, "Failed to parse URL: %s\n", 

--- a/tests/prog_reconnect.c
+++ b/tests/prog_reconnect.c
@@ -34,10 +34,6 @@
 #include "iscsi.h"
 #include "scsi-lowlevel.h"
 
-#ifndef discard_const
-#define discard_const(ptr) ((void *)((intptr_t)(ptr)))
-#endif
-
 const char *initiator = "iqn.2007-10.com.github:sahlberg:libiscsi:prog-reconnect";
 
 struct client_state {
@@ -194,7 +190,7 @@ int main(int argc, char *argv[])
 	struct iscsi_context *iscsi;
 	struct iscsi_url *iscsi_url = NULL;
 	struct client_state state;
-	const char *url = NULL;
+	char *url = NULL;
 	int i, c;
 	static int show_help = 0, show_usage = 0, debug = 0;
 	struct scsi_readcapacity10 *rc10;
@@ -270,10 +266,8 @@ int main(int argc, char *argv[])
 	}
 
 	iscsi_url = iscsi_parse_full_url(iscsi, url);
-	
-	if (url) {
-		free(discard_const(url));
-	}
+
+        free(url);
 
 	if (iscsi_url == NULL) {
 		fprintf(stderr, "Failed to parse URL: %s\n", 

--- a/tests/prog_reconnect_timeout.c
+++ b/tests/prog_reconnect_timeout.c
@@ -34,10 +34,6 @@
 #include "iscsi.h"
 #include "scsi-lowlevel.h"
 
-#ifndef discard_const
-#define discard_const(ptr) ((void *)((intptr_t)(ptr)))
-#endif
-
 const char *initiator = "iqn.2007-10.com.github:sahlberg:libiscsi:prog-reconnect-timeout";
 
 struct client_state {
@@ -217,7 +213,7 @@ int main(int argc, char *argv[])
 	struct iscsi_context *iscsi;
 	struct iscsi_url *iscsi_url = NULL;
 	struct client_state state;
-	const char *url = NULL;
+	char *url = NULL;
 	int i, c;
 	static int show_help = 0, show_usage = 0, debug = 0;
 	struct scsi_readcapacity10 *rc10;
@@ -293,10 +289,8 @@ int main(int argc, char *argv[])
 	}
 
 	iscsi_url = iscsi_parse_full_url(iscsi, url);
-	
-	if (url) {
-		free(discard_const(url));
-	}
+
+        free(url);
 
 	if (iscsi_url == NULL) {
 		fprintf(stderr, "Failed to parse URL: %s\n", 

--- a/tests/prog_timeout.c
+++ b/tests/prog_timeout.c
@@ -38,10 +38,6 @@
 #include "iscsi-private.h"
 #include "scsi-lowlevel.h"
 
-#ifndef discard_const
-#define discard_const(ptr) ((void *)((intptr_t)(ptr)))
-#endif
-
 const char *initiator = "iqn.2007-10.com.github:sahlberg:libiscsi:prog-timeout";
 
 void print_usage(void)
@@ -108,7 +104,7 @@ int main(int argc, char *argv[])
 {
 	struct iscsi_context *iscsi;
 	struct iscsi_url *iscsi_url = NULL;
-	const char *url = NULL;
+	char *url = NULL;
 	int c;
 	static int show_help = 0, show_usage = 0, debug = 0;
 	uint32_t count;
@@ -182,9 +178,7 @@ int main(int argc, char *argv[])
 
 	iscsi_url = iscsi_parse_full_url(iscsi, url);
 	
-	if (url) {
-		free(discard_const(url));
-	}
+        free(url);
 
 	if (iscsi_url == NULL) {
 		fprintf(stderr, "Failed to parse URL: %s\n", 

--- a/utils/iscsi-inq.c
+++ b/utils/iscsi-inq.c
@@ -31,10 +31,6 @@
 #include "iscsi.h"
 #include "scsi-lowlevel.h"
 
-#ifndef discard_const
-#define discard_const(ptr) ((void *)((intptr_t)(ptr)))
-#endif
-
 const char *initiator = "iqn.2007-10.com.github:sahlberg:libiscsi:iscsi-inq";
 
 void inquiry_block_limits(struct scsi_inquiry_block_limits *inq)
@@ -236,7 +232,7 @@ void print_help(void)
 int main(int argc, char *argv[])
 {
 	struct iscsi_context *iscsi;
-	const char *url = NULL;
+	char *url = NULL;
 	struct iscsi_url *iscsi_url = NULL;
 	int evpd = 0, pagecode = 0;
 	int show_help = 0, show_usage = 0, debug = 0;
@@ -312,10 +308,8 @@ int main(int argc, char *argv[])
 		exit(10);
 	}
 	iscsi_url = iscsi_parse_full_url(iscsi, url);
-	
-	if (url) {
-		free(discard_const(url));
-	}
+
+        free(url);
 
 	if (iscsi_url == NULL) {
 		fprintf(stderr, "Failed to parse URL: %s\n", 

--- a/utils/iscsi-ls.c
+++ b/utils/iscsi-ls.c
@@ -40,10 +40,6 @@ WSADATA wsaData;
 #include "iscsi.h"
 #include "scsi-lowlevel.h"
 
-#ifndef discard_const
-#define discard_const(ptr) ((void *)((intptr_t)(ptr)))
-#endif
-
 int showluns;
 int useurls;
 const char *initiator = "iqn.2007-10.com.github:sahlberg:libiscsi:iscsi-ls";
@@ -349,7 +345,7 @@ int main(int argc, char *argv[])
 	struct iscsi_context *iscsi;
 	struct iscsi_url *iscsi_url = NULL;
 	struct client_state state;
-	const char *url = NULL;
+	char *url = NULL;
 	int i;
 	static int show_help = 0, show_usage = 0, debug = 0;
 
@@ -418,10 +414,8 @@ int main(int argc, char *argv[])
 	}
 
 	iscsi_url = iscsi_parse_portal_url(iscsi, url);
-	
-	if (url) {
-		free(discard_const(url));
-	}
+
+        free(url);
 
 	if (iscsi_url == NULL) {
 		fprintf(stderr, "Failed to parse URL: %s\n", 

--- a/utils/iscsi-readcapacity16.c
+++ b/utils/iscsi-readcapacity16.c
@@ -26,10 +26,6 @@
 #include "iscsi.h"
 #include "scsi-lowlevel.h"
 
-#ifndef discard_const
-#define discard_const(ptr) ((void *)((intptr_t)(ptr)))
-#endif
-
 const char *initiator = "iqn.2007-10.com.github:sahlberg:libiscsi:iscsi-readcapacity16";
 
 void print_usage(void)
@@ -59,7 +55,7 @@ void print_help(void)
 int main(int argc, char *argv[])
 {
 	struct iscsi_context *iscsi;
-	const char *url = NULL;
+	char *url = NULL;
 	struct iscsi_url *iscsi_url = NULL;
 	int show_help = 0, show_usage = 0, debug = 0, size_only=0;
 	int c;
@@ -134,10 +130,8 @@ int main(int argc, char *argv[])
 		exit(10);
 	}
 	iscsi_url = iscsi_parse_full_url(iscsi, url);
-	
-	if (url) {
-		free(discard_const(url));
-	}
+
+        free(url);
 
 	if (iscsi_url == NULL) {
 		fprintf(stderr, "Failed to parse URL: %s\n", 

--- a/utils/iscsi-swp.c
+++ b/utils/iscsi-swp.c
@@ -30,10 +30,6 @@
 #include "iscsi.h"
 #include "scsi-lowlevel.h"
 
-#ifndef discard_const
-#define discard_const(ptr) ((void *)((intptr_t)(ptr)))
-#endif
-
 const char *initiator = "iqn.2007-10.com.github:sahlberg:libiscsi:iscsi-swp";
 
 
@@ -65,7 +61,7 @@ void print_help(void)
 int main(int argc, char *argv[])
 {
 	struct iscsi_context *iscsi;
-	const char *url = NULL;
+	char *url = NULL;
 	struct iscsi_url *iscsi_url = NULL;
 	int show_help = 0, show_usage = 0, debug = 0;
 	int c;
@@ -148,8 +144,8 @@ int main(int argc, char *argv[])
 		goto finished;
 	}
 	iscsi_url = iscsi_parse_full_url(iscsi, url);
-	
-	free(discard_const(url));
+
+        free(url);
 
 	if (iscsi_url == NULL) {
 		fprintf(stderr, "Failed to parse URL: %s\n", 


### PR DESCRIPTION
If "number of blocks" is 0, write_same will not erase the LBA range and
read-verify will fail.