### PR TITLE
Fix several bugs for iser

### DIFF
--- a/lib/connect.c
+++ b/lib/connect.c
@@ -418,6 +418,14 @@ int iscsi_reconnect(struct iscsi_context *iscsi)
 		return -1;
 	}
 
+	/* default transport is initialized as TCP in iscsi_create_context,
+	   we have to overwrite transport in new iscsi as old iscsi.
+	 */
+	if (iscsi_init_transport(tmp_iscsi, iscsi->transport)) {
+		ISCSI_LOG(iscsi, 2, "failed to initializing transport for reconnection");
+		return -1;
+	}
+
 	ISCSI_LOG(iscsi, 2, "reconnect initiated");
 
 	iscsi_set_targetname(tmp_iscsi, iscsi->target_name);

--- a/lib/init.c
+++ b/lib/init.c
@@ -218,7 +218,7 @@ iscsi_create_context(const char *initiator_name)
 
 	/* initalize transport of context */
 	if (iscsi_init_transport(iscsi, TCP_TRANSPORT)) {
-		iscsi_set_error(iscsi, "Failed allocating transport");
+		free(iscsi);
 		return NULL;
 	}
 

--- a/lib/init.c
+++ b/lib/init.c
@@ -393,9 +393,7 @@ iscsi_destroy_context(struct iscsi_context *iscsi)
 		return 0;
 	}
 
-	if (iscsi->fd != -1) {
-		iscsi_disconnect(iscsi);
-	}
+	iscsi_disconnect(iscsi);
 
 	iscsi_cancel_pdus(iscsi);
 

--- a/lib/iser.c
+++ b/lib/iser.c
@@ -17,6 +17,7 @@
 
 #include <sys/types.h>
 #include <sys/stat.h>
+#include <sys/prctl.h>
 #include <fcntl.h>
 #include <stdlib.h>
 #include "slist.h"
@@ -47,6 +48,9 @@
 
 
 #ifdef __linux
+
+/* the  name  can  be up to 16 bytes long, including the terminating null byte*/
+#define ISER_CM_THREAD_NAME "iscsi_cm_thread"
 
 /* MUST keep in sync with socket.c */
 union socket_address {
@@ -1369,6 +1373,9 @@ static void *cm_thread(void *arg)
 	struct rdma_cm_event event_copy;
 	int ret;
 	struct iscsi_context *iscsi = iser_conn->cma_id->context;
+
+	/* supported since Linux 2.6.9, not fatal error, ignore return value */
+	prctl(PR_SET_NAME, ISER_CM_THREAD_NAME);
 
 	while (1) {
 		ret = rdma_get_cm_event(iser_conn->cma_channel, &iser_conn->cma_event);

--- a/lib/iser.c
+++ b/lib/iser.c
@@ -1036,7 +1036,7 @@ iser_reg_mr(struct iser_conn *iser_conn)
 
 	for (i = 0 ; i < NUM_MRS ; i++) {
 
-			tx_desc = iscsi_malloc(iscsi, sizeof(*tx_desc));
+			tx_desc = iscsi_zmalloc(iscsi, sizeof(*tx_desc));
 			if (tx_desc == NULL) {
 				iscsi_set_error(iscsi, "Out-Of-Memory, failed to allocate data buffer");
 				return -1;
@@ -1478,7 +1478,7 @@ static iscsi_transport iscsi_transport_iser = {
 void iscsi_init_iser_transport(struct iscsi_context *iscsi)
 {
 	iscsi->drv = &iscsi_transport_iser;
-	iscsi->opaque = iscsi_malloc(iscsi, sizeof(struct iser_conn));
+	iscsi->opaque = iscsi_zmalloc(iscsi, sizeof(struct iser_conn));
 	iscsi->transport = ISER_TRANSPORT;
 	/* Update iSCSI params as per iSER transport */
 	iscsi->initiator_max_recv_data_segment_length = ISCSI_DEF_MAX_RECV_SEG_LEN;

--- a/lib/iser.c
+++ b/lib/iser.c
@@ -198,6 +198,7 @@ iser_free_iser_conn_res(struct iser_conn *iser_conn, bool destroy)
 
 		if (iser_conn->cmthread) {
 			pthread_cancel(iser_conn->cmthread);
+			pthread_join(iser_conn->cmthread, NULL);
 			iser_conn->cmthread = 0;
 		}
 

--- a/lib/socket.c
+++ b/lib/socket.c
@@ -425,6 +425,9 @@ iscsi_tcp_disconnect(struct iscsi_context *iscsi)
 int
 iscsi_disconnect(struct iscsi_context *iscsi)
 {
+	if (!iscsi || !iscsi->drv || !iscsi->drv->disconnect)
+		return -1;
+
         return iscsi->drv->disconnect(iscsi);
 }
 


### PR DESCRIPTION
Fix several bugs for iser, include memory leak, uncanceled thread, re-connect logic.
And test a lot about these patches, use software gateway to emulate bad/good network.

All of these patches work fine.

Test env:
```
    192.168.122.204: run as a software gateway
    192.168.122.205: run iser target, default gateway 192.168.122.204
    192.168.122.206: run QEMU as intiator, default gateway 192.168.122.204
```
    
run script on 192.168.122.204:
```
    for i in `seq 1 100`
    do
        iptables -s 192.168.122.205/32 -A FORWARD -m statistic --mode random --probability 1 -j DROP
        iptables -s 192.168.122.206/32 -A FORWARD -m statistic --mode random --probability 1 -j DROP
        sleep 30
        iptables -F
        sleep 30
    done
```
