### PR TITLE
iser: support rdma ack timeout optimization

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -152,6 +152,11 @@ if test x"$libiscsi_cv_HAVE_LINUX_ISER" = x"yes"; then
 fi
 AM_CONDITIONAL([HAVE_LINUX_ISER], [test $libiscsi_cv_HAVE_LINUX_ISER = yes])
 
+AC_TRY_COMPILE([
+#include <rdma/rdma_cma.h>],
+[return RDMA_OPTION_ID_ACK_TIMEOUT;],
+[AC_DEFINE([HAVE_RDMA_ACK_TIMEOUT],[1],[Define to 1 if you have RDMA ack timeout support])],)
+
 AC_CACHE_CHECK([whether libcunit is available],
                [ac_cv_have_cunit],
                [ac_save_CFLAGS="$CFLAGS"

--- a/include/iscsi-private.h
+++ b/include/iscsi-private.h
@@ -109,6 +109,8 @@ struct iscsi_context {
 	int tcp_syncnt;
 	int tcp_nonblocking;
 
+	unsigned char rdma_ack_timeout;
+
 	int current_phase;
 	int next_phase;
 #define ISCSI_LOGIN_SECNEG_PHASE_OFFER_CHAP         0

--- a/lib/init.c
+++ b/lib/init.c
@@ -280,6 +280,10 @@ iscsi_create_context(const char *initiator_name)
 		iscsi_set_bind_interfaces(iscsi,getenv("LIBISCSI_BIND_INTERFACES"));
 	}
 
+	if (getenv("LIBISCSI_RDMA_ACK_TIMEOUT") != NULL) {
+		iscsi->rdma_ack_timeout = (unsigned char)atoi(getenv("LIBISCSI_RDMA_ACK_TIMEOUT"));
+	}
+
 	/* iscsi->smalloc_size is the size for small allocations. this should be
 	   max(ISCSI_HEADER_SIZE, sizeof(struct iscsi_pdu), sizeof(struct iscsi_in_pdu))
 	   rounded up to the next power of 2. */
@@ -617,6 +621,8 @@ iscsi_parse_url(struct iscsi_context *iscsi, const char *url, int full)
 #ifdef HAVE_LINUX_ISER
 			} else if (!strcmp(key, "iser")) {
 				is_iser = 1;
+			} else if (!strcmp(key, "LIBISCSI_RDMA_ACK_TIMEOUT")) {
+				iscsi->rdma_ack_timeout = (unsigned char)atoi(value);
 #endif
 			}
 			tmp = next;


### PR DESCRIPTION
Since 2c1619edef61a03cb516efaa81750784c3071d10 for linux kernel and
55843c4ab8f559679d28c559cc4d681836be769b for rdma-core, rdma cma
supports RDMA_OPTION_ID_ACK_TIMEOUT. It's useful for RDMA out of
sequence case. Because this feature is added recently, we have to
check this in autogen.sh before building source code.

In production enviroument, the latency between two adapters is usually
less than 100us, so 1ms ack timeout is enough to avoid retransmission
flood.

Test under different packet loss rate and different ack timeout, run
fio (iodepth=1) in a guest os, I got this result:
latency under packet loss rate 0.00001:
	timeout 19: avg 170.22, pct99.9 215
	timeout 10: avg 160.08, pct99.9 215
	timeout 8 : avg 146.39, pct99.9 177
	timeout 7 : avg 148.37, pct99.9 211

latency under packet loss rate 0.0001:
	timeout 19: avg 949.23, pct99.9 306
	timeout 10: avg 818.53, pct99.9 378
	timeout 8 : avg 615.84, pct99.9 189
	timeout 7 : avg 618.89, pct99.9 310

Base on this test report, set default ack timeout to 8(1048.576 usec)

Suggested-by: zhuo jiang <jiangzhuo.cs@bytedance.com>
Signed-off-by: zhenwei pi <pizhenwei@bytedance.com>