### PR TITLE
specify number of blocks in write_same command

### DIFF
--- a/test-tool/test_writesame10_unmap_until_end.c
+++ b/test-tool/test_writesame10_unmap_until_end.c
@@ -53,9 +53,11 @@ test_writesame10_unmap_until_end(void)
                         i * block_size, block_size, 0, 0, 0, 0, 0, scratch,
                         EXPECT_STATUS_GOOD);
 
+                // write 0-buffer to entire range.
+                memset(scratch, 0, block_size * i);
                 logging(LOG_VERBOSE, "Unmap %d blocks using WRITESAME10", i);
                 WRITESAME10(sd, num_blocks - i,
-                            block_size, 0, 0, 1, 0, 0, scratch,
+                            block_size, i, 0, 1, 0, 0, scratch,
                             EXPECT_STATUS_GOOD);
 
                 if (rc16->lbprz) {

--- a/test-tool/test_writesame16_unmap_until_end.c
+++ b/test-tool/test_writesame16_unmap_until_end.c
@@ -58,7 +58,7 @@ test_writesame16_unmap_until_end(void)
                 logging(LOG_VERBOSE, "Unmap %d blocks using WRITESAME16", i);
                 memset(scratch, 0, block_size);
                 WRITESAME16(sd, num_blocks - i,
-                            block_size, 0, 0, 1, 0, 0, scratch,
+                            block_size, i, 0, 1, 0, 0, scratch,
                             EXPECT_STATUS_GOOD);
 
                 if (rc16->lbprz) {


### PR DESCRIPTION
If "number of blocks" is 0, write_same will not erase the LBA range and
read-verify will fail.