### PR TITLE
Iser reconnect bugfix

### DIFF
--- a/lib/iser.c
+++ b/lib/iser.c
@@ -711,6 +711,13 @@ iscsi_iser_send_pdu(struct iscsi_context *iscsi, struct iscsi_pdu *pdu) {
 	iscsi_pdu_set_expstatsn(pdu, iscsi->statsn + 1);
 	ISCSI_LIST_ADD_END(&iscsi->waitpdu, pdu);
 
+	/* because of async reconnection, before reconnecting successfully,
+	   the argument 'iscsi' is the 'old_iscsi' with a empty connection.
+	 */
+	if (!iser_conn) {
+		return 0;
+	}
+
 	if (iser_initialize_headers(iser_pdu, iser_conn)) {
 		iscsi_set_error(iscsi, "initialize headers Failed\n");
 		return -1;

--- a/lib/iser.c
+++ b/lib/iser.c
@@ -201,7 +201,6 @@ iser_free_iser_conn_res(struct iser_conn *iser_conn, bool destroy)
 	if (destroy) {
 
 		if (iser_conn->cmthread) {
-			pthread_cancel(iser_conn->cmthread);
 			pthread_join(iser_conn->cmthread, NULL);
 			iser_conn->cmthread = 0;
 		}


### PR DESCRIPTION
This PR includes 2 patches about iSER reconnection:

1. iser: fix crash for sending pdu during reconnecting
2. iser: fix hang in rdma_destroy_id