### PR TITLE
test/xcopy: minor clean up and refactoring

### DIFF
--- a/test-tool/iscsi-support.c
+++ b/test-tool/iscsi-support.c
@@ -2867,6 +2867,7 @@ int extendedcopy(struct scsi_device *sdev, struct iscsi_data *data, int status, 
         return ret;
 }
 
+/* return the length for a give descriptor type, including any SD header */
 int get_desc_len(enum ec_descr_type_code desc_type)
 {
         int desc_len = 0;
@@ -2874,16 +2875,16 @@ int get_desc_len(enum ec_descr_type_code desc_type)
                 /* Segment Descriptors */
                 case BLK_TO_STRM_SEG_DESCR:
                 case STRM_TO_BLK_SEG_DESCR:
-                        desc_len = 0x18;
+                        desc_len = 0x14 + SEG_DESC_SRC_INDEX_OFFSET;
                         break;
                 case BLK_TO_BLK_SEG_DESCR:
-                        desc_len = 0x1C;
+                        desc_len = 0x18 + SEG_DESC_SRC_INDEX_OFFSET;
                         break;
                 case STRM_TO_STRM_SEG_DESCR:
-                        desc_len = 0x14;
+                        desc_len = 0x10 + SEG_DESC_SRC_INDEX_OFFSET;
                         break;
 
-                        /* Target Descriptors */
+                /* Target Descriptors */
                 case IPV6_TGT_DESCR:
                 case IP_COPY_SVC_TGT_DESCR:
                         desc_len = 64;

--- a/test-tool/iscsi-support.h
+++ b/test-tool/iscsi-support.h
@@ -914,9 +914,9 @@ int clear_swp(struct scsi_device *sdev);
 
 int extendedcopy(struct scsi_device *sdev, struct iscsi_data *data, int status, enum scsi_sense_key key, int *ascq, int num_ascq);
 int get_desc_len(enum ec_descr_type_code desc_type);
-int populate_tgt_desc(unsigned char *desc, enum ec_descr_type_code desc_type, int luid_type, int nul, int peripheral_type, int rel_init_port_id, int pad, struct scsi_device *dev);
-int populate_seg_desc_hdr(unsigned char *hdr, enum ec_descr_type_code desc_type, int dc, int cat, int src_index, int dst_index);
-int populate_seg_desc_b2b(unsigned char *desc, int dc, int cat, int src_index, int dst_index, int num_blks, uint64_t src_lba, uint64_t dst_lba);
+int populate_tgt_desc(unsigned char *desc, enum ec_descr_type_code desc_type, int luid_type, int nul, int peripheral_type, uint16_t rel_init_port_id, int pad, struct scsi_device *dev);
+int populate_seg_desc_hdr(unsigned char *hdr, enum ec_descr_type_code desc_type, int dc, int cat, uint16_t src_index, uint16_t dst_index);
+int populate_seg_desc_b2b(unsigned char *desc, int dc, int cat, int src_index, int dst_index, uint16_t num_blks, uint64_t src_lba, uint64_t dst_lba);
 void populate_param_header(unsigned char *buf, int list_id, int str, int list_id_usage, int prio, int tgt_desc_len, int seg_desc_len, int inline_data_len);
 int receive_copy_results(struct scsi_task **task, struct scsi_device *sdev,
                          enum scsi_copy_results_sa sa, int list_id,


### PR DESCRIPTION
These changes are preparation for adding test support for 0x0A type XCOPY segment descriptors.