### PR TITLE
iscsi-command: assign `pdu->cmdsn` of data-out pdus with the current …

### DIFF
--- a/lib/iscsi-command.c
+++ b/lib/iscsi-command.c
@@ -99,7 +99,7 @@ iscsi_send_data_out(struct iscsi_context *iscsi, struct iscsi_pdu *cmd_pdu,
 		/* set the cmdsn in the pdu struct so we can compare with
 		 * maxcmdsn when sending to socket even if data-out pdus
 		 * do not carry a cmdsn on the wire */
-		pdu->cmdsn                    = cmd_pdu->cmdsn;
+		pdu->cmdsn                    = iscsi->cmdsn;
 
 		if (tot_len == len) {
 			flags = ISCSI_PDU_SCSI_FINAL;


### PR DESCRIPTION
…cmdsn

A data-out pdu doesn't have a cmdsn actually, the cmdsn assigned to the
pdu struct is only for local comparison. But taking the value of
`cmd_pdu->cmdsn` is not safe.
Function `iscsi_add_to_outqueue()`(in socket.c) rewrites the cmdsn of immediate
pdus with the cmdsn of the first element in the outqueue, and if the element
is a data-out pdu, the cmdsn will be less than `expcmdsn` and cause an error.

Related error logs:
libiscsi: iscsi_write_to_socket: outqueue[0]->cmdsn < expcmdsn (3648bab5 < 3648bab9) opcode 00 [iqn.2003-01.org.linux-iscsi.tgt0]
libiscsi: reconnect initiated [iqn.2003-01.org.linux-iscsi.tgt0]
libiscsi: connecting to portal 127.0.0.1 [iqn.2003-01.org.linux-iscsi.tgt0]
libiscsi: connection established (127.0.0.1:62404 -> 127.0.0.1) [iqn.2003-01.org.linux-iscsi.tgt0]

Signed-off-by: wanghonghao <wanghonghao@bytedance.com>