### PR TITLE
iscsi-ls: Fix iser url scheme parsing

### DIFF
--- a/utils/iscsi-ls.c
+++ b/utils/iscsi-ls.c
@@ -376,7 +376,8 @@ int main(int argc, char *argv[])
                 } else if (!strcmp(argv[i], "-U") ||
                            !strcmp(argv[i], "--url")) {
 			useurls = 1;
-                } else if (!strncmp("iscsi://", argv[i], 8)) {
+                } else if (!strncmp("iscsi://", argv[i], 8) ||
+                           !strncmp("iser://", argv[i], 7)) {
                         url = strdup(argv[i]);
                 }
         }


### PR DESCRIPTION
Libiscsi supports to parse two iscsi url schemes: 'iscsi://' and 'iser://'.
Fix the missing iser parsing, introduced from 12222077.

Signed-off-by: Han Han <hhan@redhat.com>