### PR TITLE
test-tool: Fix CmdSN tests

### DIFF
--- a/test-tool/test_iscsi_cmdsn_toohigh.c
+++ b/test-tool/test_iscsi_cmdsn_toohigh.c
@@ -35,10 +35,12 @@ static int my_iscsi_queue_pdu(struct iscsi_context *iscsi, struct iscsi_pdu *pdu
 		 * iscsi_pdu_set_cmdsn(), which also changes pdu->cmdsn?
 		 */
                 scsi_set_uint32(&pdu->outdata.data[24], iscsi->maxcmdsn + 1);
-                /* fudge the cmdsn value back to where it should be if this
-                 * pdu is ignored.
+                /*
+                 * Fudge the cmdsn value back to where it should be if this pdu
+                 * is ignored. The cmdsn value will be incremented by the
+                 * orig_queue_pdu(), so it's off by one.
                  */
-                iscsi->cmdsn = iscsi->expcmdsn;
+                iscsi->cmdsn = iscsi->expcmdsn - 1;
                 break;
         }
 

--- a/test-tool/test_iscsi_cmdsn_toolow.c
+++ b/test-tool/test_iscsi_cmdsn_toolow.c
@@ -35,10 +35,12 @@ static int my_iscsi_queue_pdu(struct iscsi_context *iscsi, struct iscsi_pdu *pdu
 		 * iscsi_pdu_set_cmdsn(), which also changes pdu->cmdsn?
 		 */
                 scsi_set_uint32(&pdu->outdata.data[24], iscsi->expcmdsn - 1);
-                /* fudge the cmdsn value back to where it should be if this
-                 * pdu is ignored.
+                /*
+                 * Fudge the cmdsn value back to where it should be if this pdu
+                 * is ignored. The cmdsn value will be incremented by the
+                 * orig_queue_pdu(), so it's off by one.
                  */
-                iscsi->cmdsn = iscsi->expcmdsn;
+                iscsi->cmdsn = iscsi->expcmdsn - 1;
                 break;
         }
 


### PR DESCRIPTION
After commit 10868c491d1d16fe2879fdba30a95d855fa936a6 CmdSN tests no
longer work because iscsi->cmdsn is incremented during the second test
phase (sending "good" TUR after "bad" TUR), so the resulting CmdSN is
not ExpCmdSN, but ExpCmdSN + 1 that is not acknowledged by the target.
This commit fixes the issue by setting iscsi->cmdsn to iscsi->expcmdsn - 1.

Affected tests:

 * iSCSI.iSCSIcmdsn.iSCSICmdSnTooLow
 * iSCSI.iSCSIcmdsn.iSCSICmdSnTooHigh