### PR TITLE
init: fix Wformat on 32-bit platforms

### DIFF
--- a/lib/init.c
+++ b/lib/init.c
@@ -293,7 +293,7 @@ iscsi_create_context(const char *initiator_name)
 	while (iscsi->smalloc_size < required) {
 		iscsi->smalloc_size <<= 1;
 	}
-	ISCSI_LOG(iscsi,5,"small allocation size is %lu byte", iscsi->smalloc_size);
+	ISCSI_LOG(iscsi,5,"small allocation size is %zu byte", iscsi->smalloc_size);
 
 	ca = getenv("LIBISCSI_CACHE_ALLOCATIONS");
 	if (!ca || atoi(ca) != 0) {


### PR DESCRIPTION
Otherwise:
```
In file included from init.c:42:
init.c: In function 'iscsi_create_context':
init.c:296:20: error: format '%lu' expects argument of type 'long unsigned int', but argument 4 has type 'size
  296 |  ISCSI_LOG(iscsi,5,"small allocation size is %lu byte", iscsi->smalloc_size);
      |                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~  ~~~~~~~~~~~~~~~~~~~
      |                                                              |
      |                                                              size_t {aka unsigned int}
./../include/iscsi-private.h:357:36: note: in definition of macro 'ISCSI_LOG'
  357 |    iscsi_log_message(iscsi, level, format, ## __VA_ARGS__); \
      |                                    ^~~~~~
init.c:296:48: note: format string is defined here
  296 |  ISCSI_LOG(iscsi,5,"small allocation size is %lu byte", iscsi->smalloc_size);
      |                                              ~~^
      |                                                |
      |                                                long unsigned int
      |                                              %u
init.c: At top level:
```