### PR TITLE
test-tool: test various ALLOC LENGTHS for REPORT LUNS

### DIFF
--- a/test-tool/iscsi-test-cu.c
+++ b/test-tool/iscsi-test-cu.c
@@ -309,6 +309,7 @@ static CU_TestInfo tests_receive_copy_results[] = {
 
 static CU_TestInfo tests_report_luns[] = {
 	{ "Simple", test_report_luns_simple },
+	{ "AllocLen", test_report_luns_alloclen },
 	CU_TEST_INFO_NULL
 };
 

--- a/test-tool/iscsi-test-cu.h
+++ b/test-tool/iscsi-test-cu.h
@@ -191,6 +191,7 @@ void test_receive_copy_results_copy_status(void);
 void test_receive_copy_results_op_params(void);
 
 void test_report_luns_simple(void);
+void test_report_luns_alloclen(void);
 
 void test_report_supported_opcodes_one_command(void);
 void test_report_supported_opcodes_rctd(void);

--- a/test-tool/test_report_luns.c
+++ b/test-tool/test_report_luns.c
@@ -19,6 +19,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <stdlib.h>
+#include <poll.h>
 
 #include <CUnit/CUnit.h>
 
@@ -63,4 +64,91 @@ test_report_luns_simple(void)
 	}
 
 	scsi_free_scsi_task(rl_task);
+}
+
+struct tests_report_luns_state {
+	uint32_t io_dispatched;
+	uint32_t io_completed;
+};
+
+static void
+test_report_luns_cb(struct iscsi_context *iscsi __attribute__((unused)),
+		    int status, void *command_data,
+		    void *private_data)
+{
+	struct scsi_task *rl_task = command_data;
+	struct tests_report_luns_state *state = private_data;
+
+	state->io_completed++;
+	CU_ASSERT_EQUAL(status, SCSI_STATUS_GOOD);
+	scsi_free_scsi_task(rl_task);
+}
+
+static void
+test_report_luns_invalid_cb(struct iscsi_context *iscsi __attribute__((unused)),
+			    int status, void *command_data, void *private_data)
+{
+	struct scsi_task *rl_task = command_data;
+	struct tests_report_luns_state *state = private_data;
+
+	state->io_completed++;
+	CU_ASSERT_EQUAL(status, SCSI_STATUS_CHECK_CONDITION);
+	CU_ASSERT_EQUAL(rl_task->sense.key, SCSI_SENSE_ILLEGAL_REQUEST);
+	CU_ASSERT_EQUAL(rl_task->sense.ascq,
+			SCSI_SENSE_ASCQ_INVALID_FIELD_IN_CDB);
+	scsi_free_scsi_task(rl_task);
+}
+
+void
+test_report_luns_alloclen(void)
+{
+	struct tests_report_luns_state state = { };
+	struct scsi_task *rl_task;
+	int ret;
+	int i;
+
+	logging(LOG_VERBOSE, LOG_BLANK_LINE);
+	logging(LOG_VERBOSE, "Test REPORT LUNS - ALLOCATION LENGTH");
+
+	/*
+	 * SPC-3 6.21 REPORT LUNS command:
+	 * NOTE 30 - Device servers compliant with SPC return CHECK CONDITION
+	 * status, with the sense key set to ILLEGAL REQUEST, and the additional
+	 * sense code set to INVALID FIELD IN CDB when the allocation length is
+	 * less than 16 bytes.
+	 *
+	 * Don't use iscsi_reportluns_task(), as it blocks invalid alloc len
+	 */
+	for (i = 0; i < 32; i++) {
+		iscsi_command_cb cb;
+
+		rl_task = scsi_reportluns_cdb(0,	/* SELECT REPORT */
+					      i);	/* ALLOCATION LENGTH */
+		CU_ASSERT_PTR_NOT_NULL_FATAL(rl_task);
+
+		if (i < 16)
+			cb = test_report_luns_invalid_cb;
+		else
+			cb = test_report_luns_cb;
+		/* report luns are always sent to lun 0 */
+		ret = iscsi_scsi_command_async(sd->iscsi_ctx, 0, rl_task, cb,
+					       NULL, &state);
+		CU_ASSERT_EQUAL(ret, 0);
+		state.io_dispatched++;
+	}
+
+	logging(LOG_VERBOSE, "Awaiting completion of %d REPORT LUNS requests",
+		state.io_dispatched);
+	while (state.io_completed < state.io_dispatched) {
+		struct pollfd pfd;
+
+		pfd.fd = iscsi_get_fd(sd->iscsi_ctx);
+		pfd.events = iscsi_which_events(sd->iscsi_ctx);
+
+		ret = poll(&pfd, 1, -1);
+		CU_ASSERT_NOT_EQUAL(ret, -1);
+
+		ret = iscsi_service(sd->iscsi_ctx, pfd.revents);
+		CU_ASSERT_EQUAL(ret, 0);
+	}
 }


### PR DESCRIPTION
SPC-3 6.21 REPORT LUNS command states:
  Device servers compliant with SPC return CHECK CONDITION status, with
  the sense key set to ILLEGAL REQUEST, and the additional sense code
  set to INVALID FIELD IN CDB when the allocation length is less than
  16 bytes.

Test this requirement by sending REPORT LUNS requests with ALLOCATION
LENGTH values under, equal to and over 16 bytes.

Signed-off-by: David Disseldorp <ddiss@suse.de>