### PR TITLE
Add header <strings.h> for strncasecmp

### DIFF
--- a/utils/iscsi-ls.c
+++ b/utils/iscsi-ls.c
@@ -37,6 +37,7 @@ WSADATA wsaData;
 #include <stdlib.h>
 #include <stdint.h>
 #include <string.h>
+#include <strings.h>
 #include "iscsi.h"
 #include "scsi-lowlevel.h"
 


### PR DESCRIPTION
Otherwise:
```
../../libiscsi-1.19.0/utils/iscsi-ls.c:181:6: error: implicitly declaring library function 'strncasecmp' with type 'int (const char *, const char *, unsigned long)' [-Werror,-Wimplicit-function-declaration]
        if (strncasecmp(portal, "[fe80:", 6) == 0) {
            ^
../../libiscsi-1.19.0/utils/iscsi-ls.c:181:6: note: include the header <strings.h> or explicitly provide a declaration for 'strncasecmp'
1 error generated.
*** [iscsi-ls.o] Error code 1
```