### PR TITLE
Makefile.am improvements.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -15,7 +15,6 @@ AUTOMAKE_OPTIONS = foreign subdir-objects
 AM_CPPFLAGS=-I. -I$(srcdir)/include "-D_U_=__attribute__((unused))" \
 	"-D_R_(A,B)=__attribute__((format(printf,A,B)))"
 AM_CFLAGS=$(WARN_CFLAGS)
-LDADD = lib/libiscsi.la
 
 EXTRA_DIST = autogen.sh COPYING LICENCE-GPL-2.txt LICENCE-LGPL-2.1.txt \
 	     packaging/RPM/libiscsi.spec.in packaging/RPM/makerpms.sh \

--- a/examples/Makefile.am
+++ b/examples/Makefile.am
@@ -1,6 +1,7 @@
 AM_CPPFLAGS=-I. -I${srcdir}/../include "-D_U_=__attribute__((unused))" \
 	"-D_R_(A,B)=__attribute__((format(printf,A,B)))"
 AM_CFLAGS=$(WARN_CFLAGS)
+AM_LDFLAGS=-no-undefined
 LIBS=../lib/libiscsi.la
 
 noinst_PROGRAMS = iscsiclient iscsi-dd

--- a/examples/Makefile.am
+++ b/examples/Makefile.am
@@ -1,6 +1,6 @@
 AM_CPPFLAGS=-I. -I${srcdir}/../include "-D_U_=__attribute__((unused))" \
 	"-D_R_(A,B)=__attribute__((format(printf,A,B)))"
 AM_CFLAGS=$(WARN_CFLAGS)
-LDADD = ../lib/libiscsi.la
+LIBS=../lib/libiscsi.la
 
 noinst_PROGRAMS = iscsiclient iscsi-dd

--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -20,6 +20,8 @@ if HAVE_LINUX_ISER
 libiscsipriv_la_LIBADD = -libverbs -lrdmacm -lpthread
 endif
 
+libiscsipriv_la_LDFLAGS = -no-undefined
+
 libiscsipriv_la_CPPFLAGS = -I${srcdir}/../include -I$(srcdir)/include \
 	"-D_U_=__attribute__((unused))" \
 	"-D_R_(A,B)=__attribute__((format(printf,A,B)))"

--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -17,7 +17,7 @@ libiscsipriv_la_SOURCES += iser.c
 endif
 
 if HAVE_LINUX_ISER
-libiscsipriv_la_LDFLAGS = -libverbs -lrdmacm -lpthread
+libiscsipriv_la_LIBADD = -libverbs -lrdmacm -lpthread
 endif
 
 libiscsipriv_la_CPPFLAGS = -I${srcdir}/../include -I$(srcdir)/include \

--- a/test-tool/Makefile.am
+++ b/test-tool/Makefile.am
@@ -2,6 +2,7 @@ AM_CPPFLAGS=-I. -I${srcdir}/../include \
 	"-D_U_=__attribute__((unused)) " \
 	"-D_R_(A,B)=__attribute__((format(printf,A,B)))"
 AM_CFLAGS=$(WARN_CFLAGS)
+AM_LDFLAGS=-no-undefined
 LIBS = ../lib/libiscsipriv.la
 
 EXTRA_DIST = README

--- a/test-tool/Makefile.am
+++ b/test-tool/Makefile.am
@@ -2,7 +2,7 @@ AM_CPPFLAGS=-I. -I${srcdir}/../include \
 	"-D_U_=__attribute__((unused)) " \
 	"-D_R_(A,B)=__attribute__((format(printf,A,B)))"
 AM_CFLAGS=$(WARN_CFLAGS)
-LDADD = ../lib/libiscsipriv.la
+LIBS = ../lib/libiscsipriv.la
 
 EXTRA_DIST = README
 

--- a/test-tool/Makefile.am
+++ b/test-tool/Makefile.am
@@ -13,7 +13,7 @@ dist_noinst_HEADERS = iscsi-support.h \
 # libiscsi test tool using cunit
 if ISCSITEST
 bin_PROGRAMS = iscsi-test-cu
-iscsi_test_cu_LDFLAGS = -ldl -lcunit
+iscsi_test_cu_LDADD = -ldl -lcunit
 iscsi_test_cu_SOURCES = iscsi-test-cu.c \
 	iscsi-support.c \
 	iscsi-multipath.c \

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -1,7 +1,7 @@
 AM_CPPFLAGS = -I${srcdir}/../include "-D_U_=__attribute__((unused))" \
 	"-D_R_(A,B)=__attribute__((format(printf,A,B)))"
 AM_CFLAGS = $(WARN_CFLAGS)
-LDADD = ../lib/libiscsi.la
+LIBS = ../lib/libiscsi.la
 
 noinst_PROGRAMS = prog_reconnect prog_reconnect_timeout prog_noop_reply \
 	prog_readwrite_iov prog_timeout prog_read_all_pdus \

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -1,6 +1,7 @@
 AM_CPPFLAGS = -I${srcdir}/../include "-D_U_=__attribute__((unused))" \
 	"-D_R_(A,B)=__attribute__((format(printf,A,B)))"
 AM_CFLAGS = $(WARN_CFLAGS)
+AM_LDFLAGS = -no-undefined
 LIBS = ../lib/libiscsi.la
 
 noinst_PROGRAMS = prog_reconnect prog_reconnect_timeout prog_noop_reply \

--- a/utils/Makefile.am
+++ b/utils/Makefile.am
@@ -1,6 +1,7 @@
 AM_CPPFLAGS = -I${srcdir}/../include "-D_U_=__attribute__((unused))" \
 	"-D_R_(A,B)=__attribute__((format(printf,A,B)))"
 AM_CFLAGS = $(WARN_CFLAGS)
+AM_LDFLAGS = -no-undefined
 LIBS = ../lib/libiscsi.la
 
 bin_PROGRAMS = iscsi-inq iscsi-ls iscsi-perf iscsi-readcapacity16 \

--- a/utils/Makefile.am
+++ b/utils/Makefile.am
@@ -1,7 +1,7 @@
 AM_CPPFLAGS = -I${srcdir}/../include "-D_U_=__attribute__((unused))" \
 	"-D_R_(A,B)=__attribute__((format(printf,A,B)))"
 AM_CFLAGS = $(WARN_CFLAGS)
-LDADD = ../lib/libiscsi.la
+LIBS = ../lib/libiscsi.la
 
 bin_PROGRAMS = iscsi-inq iscsi-ls iscsi-perf iscsi-readcapacity16 \
 	iscsi-swp


### PR DESCRIPTION
These are some improvements for the `Makefile.am` files.

1. When linking dependencies for the whole `Makefile.am` the variable is `LIBS`, not `LDADD`. This removes `LDADD` and replaces it with `LIBS` as needed.
2. When linking dependencies the correct variable is `libfoo_LIBADD` for libraries and `foo_LDADD` for programs while `LDFLAGS` should only be used for other linker flags such as `-no-undefined` or `-version-info`.
3.  This adds `-no-undefined` where applicable to help detect the undefined references fixed in the first commit. Please note that GNU libtool has a long standing design where `-no-undefined` is silently ignored and will not be respected. However when using slibtool (https://dev.midipix.org/cross/slibtool) this will not be a problem and `-no-undefined` works as expected.