### PR TITLE
Inquiry for Block Device Charactertics expected to succeed always

### DIFF
--- a/test-tool/Makefile.am
+++ b/test-tool/Makefile.am
@@ -37,6 +37,7 @@ iscsi_test_cu_SOURCES = iscsi-test-cu.c \
 	test_inquiry_standard.c \
 	test_inquiry_supported_vpd.c \
 	test_inquiry_version_descriptors.c \
+	test_inquiry_block_device_characteristics.c \
 	test_iscsi_cmdsn_toohigh.c \
 	test_iscsi_cmdsn_toolow.c \
 	test_iscsi_datasn_invalid.c \

--- a/test-tool/iscsi-test-cu.c
+++ b/test-tool/iscsi-test-cu.c
@@ -87,6 +87,7 @@ static CU_TestInfo tests_inquiry[] = {
         { "AllocLength", test_inquiry_alloc_length},
         { "EVPD", test_inquiry_evpd},
         { "BlockLimits", test_inquiry_block_limits},
+        { "BlockDeviceCharacteristics", test_inquiry_block_device_characteristics},
         { "MandatoryVPDSBC", test_inquiry_mandatory_vpd_sbc},
         { "SupportedVPD", test_inquiry_supported_vpd},
         { "VersionDescriptors", test_inquiry_version_descriptors},
@@ -1399,19 +1400,6 @@ main(int argc, char *argv[])
 
                 inq_bl = scsi_datain_unmarshall(inq_bl_task);
                 if (inq_bl == NULL) {
-                        printf("failed to unmarshall inquiry datain blob\n");
-                        goto err_sds_free;
-                }
-        }
-
-        /* try reading block device characteristics vpd */
-        inquiry(sd, &inq_bdc_task, 1, SCSI_INQUIRY_PAGECODE_BLOCK_DEVICE_CHARACTERISTICS, 255,
-                EXPECT_STATUS_GOOD);
-        if (inq_bdc_task == NULL || inq_bdc_task->status != SCSI_STATUS_GOOD) {
-                printf("Failed to read Block Device Characteristics page\n");
-        } else {
-                inq_bdc = scsi_datain_unmarshall(inq_bdc_task);
-                if (inq_bdc == NULL) {
                         printf("failed to unmarshall inquiry datain blob\n");
                         goto err_sds_free;
                 }

--- a/test-tool/iscsi-test-cu.h
+++ b/test-tool/iscsi-test-cu.h
@@ -77,6 +77,7 @@ void test_inquiry_mandatory_vpd_sbc(void);
 void test_inquiry_standard(void);
 void test_inquiry_supported_vpd(void);
 void test_inquiry_version_descriptors(void);
+void test_inquiry_block_device_characteristics(void);
 
 void test_iscsi_cmdsn_toohigh(void);
 void test_iscsi_cmdsn_toolow(void);

--- a/test-tool/test_inquiry_block_device_characteristics.c
+++ b/test-tool/test_inquiry_block_device_characteristics.c
@@ -1,0 +1,55 @@
+/* 
+   Copyright (C) 2013 by Ronnie Sahlberg <ronniesahlberg@gmail.com>
+   
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; either version 2 of the License, or
+   (at your option) any later version.
+   
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+   
+   You should have received a copy of the GNU General Public License
+   along with this program; if not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <stdio.h>
+
+#include <CUnit/CUnit.h>
+
+#include "iscsi.h"
+#include "scsi-lowlevel.h"
+#include "iscsi-support.h"
+#include "iscsi-test-cu.h"
+
+void test_inquiry_block_device_characteristics(void)
+{
+        int ret;
+
+        logging(LOG_VERBOSE, LOG_BLANK_LINE);
+        logging(LOG_VERBOSE, "Test INQUIRY block device characteristics");
+
+        logging(LOG_VERBOSE, "Check if we can read the block device characteristics page");
+        ret = inquiry(sd, &task,
+                      1, SCSI_INQUIRY_PAGECODE_BLOCK_DEVICE_CHARACTERISTICS, 255,
+                      EXPECT_STATUS_GOOD);
+        CU_ASSERT_EQUAL(ret, 0);
+
+        logging(LOG_VERBOSE, "Verify we can unmarshall the DATA-IN buffer");
+        inq_bdc = scsi_datain_unmarshall(task);
+        CU_ASSERT_NOT_EQUAL(inq_bdc, NULL);
+        if (inq_bdc == NULL)
+        {
+                logging(LOG_NORMAL, "[FAILED] Failed to unmarshall DATA-IN "
+                                    "buffer");
+                return;
+        }
+
+        if (task != NULL)
+        {
+                scsi_free_scsi_task(task);
+                task = NULL;
+        }
+}


### PR DESCRIPTION
In the iscsi-test-cu.c, inquiry is being issued with block device characteristics page and if the command fails with any error other than invalid opcode, it causes a test failure. However, block device characteristics page is an optional command and the target may not be supporting this inquiry. So as a fix moved the test out of the main test code and made it part of the inquiry test suites.