### PR TITLE
configure.ac: Quote argument to m4_esyscmd() properly

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,5 +1,5 @@
 AC_PREREQ([2.69])
-AC_INIT([libiscsi], m4_esyscmd(grep 'Version:' ./packaging/RPM/libiscsi.spec.in 2>/dev/null | head -1 | sed -e 's/[ \t]*Version:[ \t]*\([^ \t]*\)[ \t]*.*/\1/' | tr -d '\n'))
+AC_INIT([libiscsi], m4_esyscmd([grep 'Version:' ./packaging/RPM/libiscsi.spec.in 2>/dev/null | head -1 | sed -e 's/[ \t]*Version:[ \t]*\([^ \t]*\)[ \t]*.*/\1/' | tr -d '\n']))
 AC_CONFIG_SRCDIR([lib/init.c])
 AC_CONFIG_MACRO_DIR([m4])
 


### PR DESCRIPTION
In one of recent commits the argument passed to m4_esyscmd()
macro was switched to its unescaped version. This is not correct
because package version is then defined as "Version 1.19.0"
instead of just "1.19.0".

Fixes: cb4489776b2659d4ea8771d3ac7ba9323f34d863
Signed-off-by: Michal Privoznik <mprivozn@redhat.com>