### PR TITLE
iscsi-command: Fix leak in iscsi_send_data_out

### DIFF
--- a/lib/iscsi-command.c
+++ b/lib/iscsi-command.c
@@ -131,6 +131,7 @@ iscsi_send_data_out(struct iscsi_context *iscsi, struct iscsi_pdu *cmd_pdu,
 		if (iscsi_queue_pdu(iscsi, pdu) != 0) {
 			iscsi_set_error(iscsi, "Out-of-memory: failed to queue iscsi "
 				"scsi pdu.");
+			iscsi->drv->free_pdu(iscsi, pdu);
 			goto error;
 		}
 


### PR DESCRIPTION
In iscsi_send_data_out() a PDU is allocated, but there is no error
handling logic to free it if the PDU cannot be queued.
iscsi_allocate_pdu() may allocate memory for the PDU. This memory may be
leaked if iscsi_queue_pdu() fails since there is no call to free it.

Orignally there was a free() call but it was removed as a part of a
cleanup adding checks for NULL pdu callbacks.

Fixes: 423b82efa4bd ("pdu: check callback for NULL everywhere")
Reviewed-by: Manish Mishra <manish.mishra@nutanix.com>
Signed-off-by: Raphael Norwitz <raphael.norwitz@nutanix.com>