### PR TITLE
Fix to lose the immediate data param during login processing

### DIFF
--- a/lib/login.c
+++ b/lib/login.c
@@ -1220,9 +1220,6 @@ iscsi_process_login_reply(struct iscsi_context *iscsi, struct iscsi_pdu *pdu,
 				 * the target said. ImmediateData is NO.
 				 */
 				iscsi->use_immediate_data = ISCSI_IMMEDIATE_DATA_NO;
-
-			} else {
-				iscsi->use_immediate_data = ISCSI_IMMEDIATE_DATA_YES;
 			}
 		}
 


### PR DESCRIPTION
If a test sets the use_immediate_data parameter to ISCSI_IMMEDIATE_DATA_NO
for the iSCSI context, then the test expects that a data associated with
the Write command to be sent in a separate PDU.

But if for execute the command it is necessary to login on a target then
the use_immediate_data was previously set, will be rewrite during
the processing of the Login Response packet.

This happen during the iSCSI.iSCSIdatasn.iSCSIDataSnInvalid
(test_iscsi_datasn_invalid.c) test:

```
    --> iSCSI 114 SCSI: Write(10) LUN: 0x01 (LBA: 0x00000064, Len: 1)
    <-- iSCSI 114 Ready To Transfer
    --> iSCSI 578 SCSI: Data Out LUN: 0x01 (Write(10) Request Data)

    --> iSCSI 550 Login Command
Here we lose use_immediate_data value for iSCSI session.
    <-- iSCSI 426 Login Response (Success)
    --> iSCSI 114 SCSI: Test Unit Ready LUN: 0x01
    <-- iSCSI 114 SCSI: Response LUN: 0x01 (Test Unit Ready) (Good)
And this Write command includes payload into iSCSI PDU packet, but should not do it.
    --> iSCSI 578 SCSI: Write(10) LUN: 0x01 (LBA: 0x00000064, Len: 1)SCSI: Data Out LUN: 0x01 (Write(10) Request Data)
    <-- iSCSI 114 SCSI: Response LUN: 0x01 (Write(10)) (Good)

    --> iSCSI 114 SCSI: Write(10) LUN: 0x01 (LBA: 0x00000064, Len: 2)
    <-- iSCSI 114 Ready To Transfer
    --> iSCSI 578 SCSI: Data Out LUN: 0x01 (Write(10) Request Data)
    --> iSCSI 626 SCSI: Data Out LUN: 0x01 (Write(10) Request Data)
```
