### PR TITLE
iscsi-inq: handle setting of debug_level correctly

### DIFF
--- a/utils/iscsi-inq.c
+++ b/utils/iscsi-inq.c
@@ -241,7 +241,7 @@ int main(int argc, char *argv[])
 	static struct option long_options[] = {
 		{"help",           no_argument,          NULL,        'h'},
 		{"usage",          no_argument,          NULL,        'u'},
-		{"debug",          no_argument,          NULL,        'd'},
+		{"debug",          required_argument,    NULL,        'd'},
 		{"initiator-name", required_argument,    NULL,        'i'},
 		{"evpd",           required_argument,    NULL,        'e'},
 		{"pagecode",       required_argument,    NULL,        'c'},
@@ -249,7 +249,7 @@ int main(int argc, char *argv[])
 	};
 	int option_index;
 
-	while ((c = getopt_long(argc, argv, "h?udi:e:c:", long_options,
+	while ((c = getopt_long(argc, argv, "h?ud:i:e:c:", long_options,
 			&option_index)) != -1) {
 		switch (c) {
 		case 'h':
@@ -260,7 +260,7 @@ int main(int argc, char *argv[])
 			show_usage = 1;
 			break;
 		case 'd':
-			debug = 1;
+			debug = atoi(optarg);
 			break;
 		case 'i':
 			initiator = optarg;


### PR DESCRIPTION
According to the man page and help info, --debug=integer can specify the
debug_level, while it would report following error:

iscsi-inq --debug=2
iscsi-inq: option '--debug' doesn't allow an argument

It's because the iscsi-inq code did not handle this parameters
correctly. So here we just correct it.

Signed-off-by: Wenchao Hao <haowenchao@huawei.com>