### PR TITLE
add check after malloc to avoid referencing an illegal pointer and fix -d param

### DIFF
--- a/examples/iscsi-dd.c
+++ b/examples/iscsi-dd.c
@@ -131,6 +131,11 @@ void read_cb(struct iscsi_context *iscsi, int status, void *command_data, void *
 	}
 
 	wt = malloc(sizeof(struct write_task));
+	if (wt == NULL) {
+		fprintf(stderr, "failed to alloc write task\n");
+		exit(10);
+	}
+	
 	wt->rt = task;
 	wt->client = client;
 
@@ -430,6 +435,11 @@ void cscd_ident_inq(struct iscsi_context *iscsi,
 	_tgt_desig->designator_type = tgt_desig->designator_type;
 	_tgt_desig->designator_length = tgt_desig->designator_length;
 	_tgt_desig->designator = malloc(tgt_desig->designator_length);
+	if (_tgt_desig->designator == NULL) {
+		fprintf(stderr, "failed to alloc designator\n");
+		exit(10);
+	}
+	
 	memcpy(_tgt_desig->designator, tgt_desig->designator, tgt_desig->designator_length);
 
 	scsi_free_scsi_task(task);

--- a/utils/iscsi-swp.c
+++ b/utils/iscsi-swp.c
@@ -75,14 +75,14 @@ int main(int argc, char *argv[])
 	static struct option long_options[] = {
 		{"help",           no_argument,          NULL,        'h'},
 		{"usage",          no_argument,          NULL,        'u'},
-		{"debug",          no_argument,          NULL,        'd'},
+		{"debug",          required_argument,    NULL,        'd'},
 		{"initiator-name", required_argument,    NULL,        'i'},
 		{"swp",            required_argument,    NULL,        's'},
 		{0, 0, 0, 0}
 	};
 	int option_index;
 
-	while ((c = getopt_long(argc, argv, "h?udi:s:", long_options,
+	while ((c = getopt_long(argc, argv, "h?ud:i:s:", long_options,
 			&option_index)) != -1) {
 		switch (c) {
 		case 'h':
@@ -93,7 +93,7 @@ int main(int argc, char *argv[])
 			show_usage = 1;
 			break;
 		case 'd':
-			debug = 1;
+			debug = atoi(optarg);
 			break;
 		case 'i':
 			initiator = optarg;


### PR DESCRIPTION
add check after malloc to avoid referencing an illegal pointer