### PR TITLE
Fix segmentation fault problem.

### DIFF
--- a/lib/pdu.c
+++ b/lib/pdu.c
@@ -622,7 +622,7 @@ iscsi_process_pdu(struct iscsi_context *iscsi, struct iscsi_in_pdu *in)
 			return -1;
 		}
 
-		if (is_finished) {
+		if (is_finished && iscsi->waitpdu != NULL) {
 			ISCSI_LIST_REMOVE(&iscsi->waitpdu, pdu);
 			iscsi->drv->free_pdu(iscsi, pdu);
 		}


### PR DESCRIPTION
When execute iscsi_task_mgmt_lun_reset_async function,
pdus are already removed from waitpdu list. In iscsi_service
function, this will call iscsi_process_pdu and release
pdu from waitpdu again, which cause segmentation fault.

Whether waitpud list is NULL should be checked here to avoid
the problem.

Signed-off-by: geruijun <geruijun@huawei.com>