### PR TITLE
aros_compat: Add check after malloc allocation

### DIFF
--- a/aros/aros_compat.c
+++ b/aros/aros_compat.c
@@ -48,6 +48,9 @@ struct addrinfo **res)
   struct sockaddr_in *sin;
 
   sin = malloc(sizeof(struct sockaddr_in));
+  if (!sin)
+    return -1;
+
   sin->sin_len = sizeof(struct sockaddr_in);
   sin->sin_family=AF_INET;
 
@@ -60,6 +63,8 @@ struct addrinfo **res)
   } 
 
   *res = malloc(sizeof(struct addrinfo));
+  if (!*res)
+    return -2;
 
   (*res)->ai_family = AF_INET;
   (*res)->ai_addrlen = sizeof(struct sockaddr_in);

--- a/lib/connect.c
+++ b/lib/connect.c
@@ -469,6 +469,10 @@ static int reconnect(struct iscsi_context *iscsi, int force)
 		tmp_iscsi->old_iscsi = iscsi->old_iscsi;
 	} else {
 		tmp_iscsi->old_iscsi = malloc(sizeof(struct iscsi_context));
+		if (!tmp_iscsi->old_iscsi) {
+			free(tmp_iscsi);
+			return -1;
+		}
 		memcpy(tmp_iscsi->old_iscsi, iscsi, sizeof(struct iscsi_context));
 	}
 	memcpy(iscsi, tmp_iscsi, sizeof(struct iscsi_context));


### PR DESCRIPTION
Increase the check after malloc allocation, which should be helpful to the robustness of the program.