### PR TITLE
utils: use strtol instead of atoi

### DIFF
--- a/utils/iscsi-inq.c
+++ b/utils/iscsi-inq.c
@@ -260,16 +260,16 @@ int main(int argc, char *argv[])
 			show_usage = 1;
 			break;
 		case 'd':
-			debug = atoi(optarg);
+			debug = strtol(optarg, NULL, 0);
 			break;
 		case 'i':
 			initiator = optarg;
 			break;
 		case 'e':
-			evpd = atoi(optarg);
+			evpd = strtol(optarg, NULL, 0);
 			break;
 		case 'c':
-			pagecode = atoi(optarg);
+			pagecode = strtol(optarg, NULL, 0);
 			break;
 		default:
 			fprintf(stderr, "Unrecognized option '%c'\n\n", c);

--- a/utils/iscsi-perf.c
+++ b/utils/iscsi-perf.c
@@ -287,13 +287,13 @@ int main(int argc, char *argv[])
 			initiator = optarg;
 			break;
 		case 'm':
-			max_in_flight = atoi(optarg);
+			max_in_flight = strtol(optarg, NULL, 0);
 			break;
 		case 't':
-			runtime = atoi(optarg);
+			runtime = strtol(optarg, NULL, 0);
 			break;
 		case 'b':
-			blocks_per_io = atoi(optarg);
+			blocks_per_io = strtol(optarg, NULL, 0);
 			break;
 		case 'n':
 			client.ignore_errors = 1;
@@ -308,7 +308,7 @@ int main(int argc, char *argv[])
 			logging = 1;
 			break;
 		case 'x':
-			client.max_reconnects = atoi(optarg);
+			client.max_reconnects = strtol(optarg, NULL, 0);
 			break;
 		case 'h':
 			usage();

--- a/utils/iscsi-pr.c
+++ b/utils/iscsi-pr.c
@@ -338,7 +338,7 @@ int main(int argc, char *argv[])
                                 break;
 
                         case 'T':
-                                type = atoi(optarg);
+                                type = strtol(optarg, NULL, 0);
                                 break;
 
                         case 'G':

--- a/utils/iscsi-swp.c
+++ b/utils/iscsi-swp.c
@@ -93,7 +93,7 @@ int main(int argc, char *argv[])
 			show_usage = 1;
 			break;
 		case 'd':
-			debug = atoi(optarg);
+			debug = strtol(optarg, NULL, 0);
 			break;
 		case 'i':
 			initiator = optarg;


### PR DESCRIPTION
HEX format is friendly to iSCSI utils, for example: ./iscsi-inq -e 0x1 -c 0xb1 iscsi://...

atoi supports decimal only, this example does not work. Use strtol(nptr, NULL, 0) to auto-detect format, then this works fine.