### PR TITLE
lun_reset cancelling lun tasks only

### DIFF
--- a/include/iscsi-private.h
+++ b/include/iscsi-private.h
@@ -293,6 +293,7 @@ void iscsi_pdu_set_ritt(struct iscsi_pdu *pdu, uint32_t ritt);
 void iscsi_pdu_set_datasn(struct iscsi_pdu *pdu, uint32_t datasn);
 void iscsi_pdu_set_bufferoffset(struct iscsi_pdu *pdu, uint32_t bufferoffset);
 void iscsi_cancel_pdus(struct iscsi_context *iscsi);
+void iscsi_cancel_lun_pdus(struct iscsi_context *iscsi, uint32_t lun);
 int iscsi_pdu_add_data(struct iscsi_context *iscsi, struct iscsi_pdu *pdu,
 		       const unsigned char *dptr, int dsize);
 int iscsi_queue_pdu(struct iscsi_context *iscsi, struct iscsi_pdu *pdu);

--- a/lib/task_mgmt.c
+++ b/lib/task_mgmt.c
@@ -130,7 +130,7 @@ iscsi_task_mgmt_lun_reset_async(struct iscsi_context *iscsi,
 		      uint32_t lun,
 		      iscsi_command_cb cb, void *private_data)
 {
-	iscsi_scsi_cancel_all_tasks(iscsi);
+	iscsi_cancel_lun_pdus(iscsi, lun);
 
 	return iscsi_task_mgmt_async(iscsi,
 		      lun, ISCSI_TM_LUN_RESET,


### PR DESCRIPTION
The existing implementation of iscsi_task_mgmt_lun_reset_async cancels all tasks in ready-to-send and wait-for-completion queues. If the ISCSI context has in-flight tasks for a different LUNs or tasks that are not LUN-specific (such as NOPIN, NOPOUT), those tasks are not supposed to be affected by the LUN reset.
Also, the tasks for the LUN being reset may have in-flight responses not affected by a concurrent LUN reset; they have to be handled accordingly.

This change cancels only the tasks for the LUN being reset if they are in the ready-to-send queue ('outqueue'). The tasks in the wait-for- completion queue should be cancelled on LUN reset completion. For example:

    iscsi_task_mgmt_lun_reset_async(iscsi, lun, lun_reset_cb, ctxt);
    ....
....
void lun_reset_cb(struct iscsi_context * iscsi, int status,
                  void * command_data, void * private_data)
{
    // 'response' field per ISCSI spec rfc7143 section 11.6.1
    uint8_t iscsi_response = *(uint8_t *)command_data;
    if (iscsi_response == 0) {
        // The LUN has been reset. No further replies are expected
        // for in-flight tasks for that LUN. Explicitly cancelling
        // the tasks in wait-for-completion queue.
        for (.. scsi_task-s in flight ..) {
            iscsi_scsi_cancel_task(iscsi, task);
        }
    } ...
}