### PR TITLE
Fix for https://github.com/sahlberg/libiscsi/issues/409

### DIFF
--- a/test-tool/iscsi-support.c
+++ b/test-tool/iscsi-support.c
@@ -2735,7 +2735,7 @@ int set_swp(struct scsi_device *sdev)
         logging(LOG_VERBOSE, "[SUCCESS] CONTROL page fetched.");
 
         ms = scsi_datain_unmarshall(sense_task);
-        if (ms == NULL) {
+        if (ms == NULL || ms->pages == NULL) {
                 logging(LOG_NORMAL, "failed to unmarshall mode sense datain "
                         "blob");
                 ret = -1;


### PR DESCRIPTION
'ms->pages' was not checked for being NULL. This can happen when a target does not return any pages.