### PR TITLE
print task-status in hex

### DIFF
--- a/test-tool/iscsi-support.c
+++ b/test-tool/iscsi-support.c
@@ -202,7 +202,7 @@ static int check_result(const char *opcode, struct scsi_device *sdev,
         }
         if (status == SCSI_STATUS_GOOD && task->status != SCSI_STATUS_GOOD) {
                 logging(LOG_NORMAL,
-                        "[FAILED] %s command failed with status %d / sense key %s(0x%02x) / ASCQ %s(0x%04x)",
+                        "[FAILED] %s command failed with status 0x%x / sense key %s(0x%02x) / ASCQ %s(0x%04x)",
                         opcode, task->status,
                         scsi_sense_key_str(task->sense.key), task->sense.key,
                         scsi_sense_ascq_str(task->sense.ascq), task->sense.ascq);


### PR DESCRIPTION
Previously, 'task->status' was printed as decimal. In iscsi.h, the
values that are put into it are defined as hexadecimal. This is a bit confusing (grepping through the code for 251658241 did not result in anything while the hex variant f000001 resulted in SCSI_STATUS_ERROR).