### PR TITLE
spelling fixes: eventhough, shoudl, asyncronous, maxium, implicity

### DIFF
--- a/packaging/RPM/libiscsi.spec.in
+++ b/packaging/RPM/libiscsi.spec.in
@@ -231,7 +231,7 @@ Test tool for iSCSI/SCSI targets
  - Change all default iqn names so they are valid iqn names.
 * Mon Jul 9 2012 : 1.5.0
  - Make sure we can handle racy eventsystems which might call us for 
-   POLLIN eventhough there is no longer any data to read from the socket.
+   POLLIN even though there is no longer any data to read from the socket.
  - Only set up tcp keepalives on systems that support them.
  - Only export symbols we really want to make public
  - FreeBSD and Illumos does not define SOL_TCP

--- a/test-tool/test_compareandwrite_miscompare.c
+++ b/test-tool/test_compareandwrite_miscompare.c
@@ -95,7 +95,7 @@ test_compareandwrite_miscompare(void)
                 for (j = 0; j < i * block_size; j++) {
                         if (scratch[j] != 'A') {
                                 logging(LOG_VERBOSE, "[FAILED] Data changed "
-                                        "eventhough there was a miscompare");
+                                        "even though there was a miscompare");
                                 CU_FAIL("Block was written to");
                                 return;
                         }
@@ -151,7 +151,7 @@ test_compareandwrite_miscompare(void)
                 for (j = 0; j < i * block_size; j++) {
                         if (scratch[j] != 'A') {
                                 logging(LOG_VERBOSE, "[FAILED] Data changed "
-                                        "eventhough there was a miscompare");
+                                        "even though there was a miscompare");
                                 CU_FAIL("Block was written to");
                                 return;
                         }

--- a/test-tool/test_sanitize_block_erase.c
+++ b/test-tool/test_sanitize_block_erase.c
@@ -161,7 +161,7 @@ check_unmap(void)
                         lbas->descriptors[i].lba + lbas->descriptors[i].num_blocks);
                 if (lbas->descriptors[i].provisioning == SCSI_PROVISIONING_TYPE_MAPPED) {
                           logging(LOG_VERBOSE, "[FAILED] Descriptor %d is MAPPED."
-                                "All descriptors shoudl be either DEALLOCATED "
+                                "All descriptors should be either DEALLOCATED "
                                 "or ANCHORED after SANITIZE", i);
                           CU_FAIL("[FAILED] LBA status descriptor is MAPPED.");
                 }

--- a/test-tool/test_sanitize_reset.c
+++ b/test-tool/test_sanitize_reset.c
@@ -58,7 +58,7 @@ test_sanitize_reset(void)
                 return;
         }
 
-        logging(LOG_VERBOSE, "Send an asyncronous SANITIZE to the target.");
+        logging(LOG_VERBOSE, "Send an asynchronous SANITIZE to the target.");
         data.size = block_size + 4;
         data.data = alloca(data.size);
         memset(&data.data[4], 0, block_size);

--- a/utils/iscsi-perf.c
+++ b/utils/iscsi-perf.c
@@ -151,7 +151,7 @@ void cb(struct iscsi_context *iscsi, int status, void *command_data, void *priva
 	if (status == SCSI_STATUS_BUSY ||
 		(status == SCSI_STATUS_CHECK_CONDITION && task->sense.key == SCSI_SENSE_UNIT_ATTENTION)) {
 		if (client->retry_cnt++ > 4 * max_in_flight) {
-			fprintf(stderr, "maxium number of command retries reached...\n");
+			fprintf(stderr, "maximum number of command retries reached...\n");
 			client->err_cnt++;
 			goto out;
 		}

--- a/utils/iscsi-pr.c
+++ b/utils/iscsi-pr.c
@@ -236,7 +236,7 @@ static void print_help(const char *bin)
         fprintf(stderr, "  -S, --param-sark=SARK          PR Out: parameter service action reservation key (SARK is in hex)\n");
         fprintf(stderr, "  -T, --prout-type=TYPE          PR Out: type field\n");
         fprintf(stderr, "  -G, --register                 PR Out: Register\n");
-        fprintf(stderr, "  -R, --reserve                  PR Out: Reserve, SARK only(register sark implicity)\n");
+        fprintf(stderr, "  -R, --reserve                  PR Out: Reserve, SARK only(register sark implicitly)\n");
         fprintf(stderr, "  -L, --release                  PR Out: Release, SARK only. This program releases TYPE 7 and TYPE 8 only\n");
         fprintf(stderr, "  -C, --clear                    PR Out: Clear, SARK only\n");
         fprintf(stderr, "  -P, --preempt                  PR Out: Preempt, use SARK to preempt reservation from RK\n");


### PR DESCRIPTION
These changes are carried in debian for a long time, some since 2016. The last one (implicity) is new in 1.20.0.