### PR TITLE
Add support for Data Digest

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Username and password for bidirectional CHAP authentication:
 target_user=<account>
 target_password=<password>
 header_digest=<crc32c|none>
+data_digest=<crc32c|none>
 Transport:
 iser
 
@@ -122,6 +123,15 @@ Header Digest
 Libiscsi supports HeaderDigest.  By default, libiscsi will offer None,CRC32C
 and let the target pick whether Header digest is to be used or not.  This can
 be overridden by an application by calling iscsi_set_header_digest() if the
+application wants to force a specific setting.
+
+
+Data Digest
+===========
+
+Libiscsi supports DataDigest.  By default, libiscsi will offer None so that
+Data digest will not be used, no matter what the target setting is.  This can
+be overridden by an application by calling iscsi_set_data_digest() if the
 application wants to force a specific setting.
 
 

--- a/include/iscsi-private.h
+++ b/include/iscsi-private.h
@@ -61,6 +61,13 @@ struct iscsi_in_pdu {
 
 	long long data_pos;
 	unsigned char *data;
+
+	/*
+	 * Some data structures wrt Data Digest (if negociated)
+	 */
+	unsigned char data_digest_buf[ISCSI_DIGEST_SIZE];
+	int received_data_digest_bytes;
+	uint32_t calculated_data_digest;
 };
 void iscsi_free_iscsi_in_pdu(struct iscsi_context *iscsi, struct iscsi_in_pdu *in);
 
@@ -105,6 +112,8 @@ struct iscsi_context {
 	uint32_t statsn;
 	enum iscsi_header_digest want_header_digest;
 	enum iscsi_header_digest header_digest;
+	enum iscsi_data_digest want_data_digest;
+	enum iscsi_data_digest data_digest;
 
 	int fd;
 	int is_connected;
@@ -272,6 +281,8 @@ struct iscsi_pdu {
 	struct iscsi_scsi_cbdata scsi_cbdata;
 	time_t scsi_timeout;
 	uint32_t expxferlen;
+
+	uint32_t calculated_data_digest;
 };
 
 struct iscsi_pdu *iscsi_allocate_pdu(struct iscsi_context *iscsi,
@@ -350,6 +361,9 @@ void* iscsi_szmalloc(struct iscsi_context *iscsi, size_t size);
 void iscsi_sfree(struct iscsi_context *iscsi, void* ptr);
 
 uint32_t crc32c(uint8_t *buf, int len);
+void crc32c_init(uint32_t *crc_ptr);
+uint32_t crc32c_chain(uint32_t crc, uint8_t *buf, int len);
+uint32_t crc32c_chain_done(uint32_t crc);
 
 struct scsi_task *iscsi_scsi_get_task_from_pdu(struct iscsi_pdu *pdu);
 

--- a/include/iscsi.h
+++ b/include/iscsi.h
@@ -336,6 +336,29 @@ EXTERN int iscsi_set_header_digest(struct iscsi_context *iscsi,
 			    enum iscsi_header_digest header_digest);
 
 /*
+ * Types of data digest we support. Default is NONE
+ */
+enum iscsi_data_digest {
+	ISCSI_DATA_DIGEST_NONE        = 0,
+	ISCSI_DATA_DIGEST_NONE_CRC32C = 1,
+	ISCSI_DATA_DIGEST_CRC32C_NONE = 2,
+	ISCSI_DATA_DIGEST_CRC32C      = 3,
+	ISCSI_DATA_DIGEST_LAST        = ISCSI_DATA_DIGEST_CRC32C
+};
+
+/*
+ * Set the desired data digest for a scsi context.
+ * Data digest can only be set/changed before the context
+ * is logged in to the target.
+ *
+ * Returns:
+ *  0: success
+ * <0: error
+ */
+EXTERN int iscsi_set_data_digest(struct iscsi_context *iscsi,
+			    enum iscsi_data_digest data_digest);
+
+/*
  * Specify the username and password to use for chap authentication
  */
 EXTERN int iscsi_set_initiator_username_pwd(struct iscsi_context *iscsi,

--- a/lib/connect.c
+++ b/lib/connect.c
@@ -431,6 +431,7 @@ static int reconnect(struct iscsi_context *iscsi, int force)
 	iscsi_set_targetname(tmp_iscsi, iscsi->target_name);
 
 	iscsi_set_header_digest(tmp_iscsi, iscsi->want_header_digest);
+	iscsi_set_data_digest(tmp_iscsi, iscsi->want_data_digest);
 
 	iscsi_set_initiator_username_pwd(tmp_iscsi, iscsi->user, iscsi->passwd);
 	iscsi_set_target_username_pwd(tmp_iscsi, iscsi->target_user, iscsi->target_passwd);

--- a/lib/crc32c.c
+++ b/lib/crc32c.c
@@ -118,3 +118,22 @@ uint32_t crc32c(uint8_t *buf, int len)
 	return crc^0xffffffff;
 }
 
+void crc32c_init(uint32_t *crc_ptr)
+{
+   if (crc_ptr)
+      *crc_ptr = 0xffffffff;
+}
+
+uint32_t crc32c_chain(uint32_t crc, uint8_t *buf, int len)
+{
+	while (len-- > 0) {
+		crc = (crc>>8) ^ crctable[(crc ^ (*buf++)) & 0xFF];
+	}
+	return crc;
+}
+
+uint32_t crc32c_chain_done(uint32_t crc)
+{
+	return crc^0xffffffff;
+}
+

--- a/lib/libiscsi.def
+++ b/lib/libiscsi.def
@@ -115,6 +115,7 @@ iscsi_set_initial_r2t
 iscsi_set_log_level
 iscsi_set_log_fn
 iscsi_set_header_digest
+iscsi_set_data_digest
 iscsi_set_initiator_username_pwd
 iscsi_set_isid_en
 iscsi_set_isid_oui

--- a/lib/libiscsi.syms.in
+++ b/lib/libiscsi.syms.in
@@ -116,6 +116,7 @@ iscsi_set_alias
 iscsi_set_bind_interfaces
 iscsi_set_cache_allocations
 iscsi_set_header_digest
+iscsi_set_data_digest
 iscsi_set_immediate_data
 iscsi_set_initial_r2t
 iscsi_set_initiator_username_pwd


### PR DESCRIPTION
This PR adds Data Digest support to `libiscsi`.

The bulk of the configuration follows the existing code for the very similar Header Digest.  The most notable difference is that Data Digest will default to `None` (rather than `None,CRC32C` as is the case for Header Digest).  This preserves exiting behavior and avoids the potentially costly Data Digest from being selected accidentally.

Since CRC32C calculations on the data may not be all computed in a single operation, components of the existing `crc32c` function (used for Header Digest) has also been decomposed into three further functions:
- `crc32c_init`
- `crc32c_chain`
- `crc32c_chain_done`

Furthermore, for the same reason we will need to "carry around" an interim digest so `calculated_data_digest` is added to both `struct iscsi_pdu` and `struct iscsi_in_pdu`.  (The latter also includes a small buffer used to receiving a data digest, which again _may_ not all come in at once.)

Also, some pertinent notes from [RFC7143 Section 11.2.3](https://www.rfc-editor.org/rfc/rfc7143#section-11.2.3) (**emphasis** mine)

> The digests, if present, are located, respectively, after the header and PDU-specific data and cover, respectively, the header and the PDU data, each **including the padding bytes**, if any.

> Digests are **not included** in data or header length fields.
> A zero-length Data Segment also **implies a zero-length Data-Digest**.