### PR TITLE
feat: add iscsi_reset_next_reconnect interface

### DIFF
--- a/include/iscsi.h
+++ b/include/iscsi.h
@@ -543,6 +543,11 @@ EXTERN int iscsi_force_reconnect(struct iscsi_context *iscsi);
 EXTERN int iscsi_force_reconnect_sync(struct iscsi_context *iscsi);
 
 /*
+ * Reset iscsi auto reconnect next_reconnect time to the current time.
+ */
+EXTERN void iscsi_reset_next_reconnect(struct iscsi_context *iscsi);
+
+/*
  * Asynchronous call to perform an ISCSI login.
  *
  * Returns:

--- a/lib/connect.c
+++ b/lib/connect.c
@@ -494,3 +494,9 @@ int iscsi_force_reconnect(struct iscsi_context *iscsi)
 {
 	return reconnect(iscsi, 1);
 }
+
+void iscsi_reset_next_reconnect(struct iscsi_context *iscsi)
+{
+	ISCSI_LOG(iscsi, 1, "reset iscsi next_reconnect");
+	iscsi->next_reconnect = time(NULL);
+}

--- a/lib/libiscsi.def
+++ b/lib/libiscsi.def
@@ -90,6 +90,7 @@ iscsi_extended_copy_task
 iscsi_receive_copy_results_sync
 iscsi_receive_copy_results_task
 iscsi_reconnect
+iscsi_reset_next_reconnect
 iscsi_sanitize_sync
 iscsi_sanitize_task
 iscsi_sanitize_block_erase_sync

--- a/lib/libiscsi.syms.in
+++ b/lib/libiscsi.syms.in
@@ -98,6 +98,7 @@ iscsi_reportluns_sync
 iscsi_reportluns_task
 iscsi_reserve6_sync
 iscsi_reserve6_task
+iscsi_reset_next_reconnect
 iscsi_sanitize_block_erase_sync
 iscsi_sanitize_block_erase_task
 iscsi_sanitize_crypto_erase_sync


### PR DESCRIPTION
When an iSCSI connection enters the reconnection phase, the backoff time (next_reconnect) increases with reconnection retry_cnt. However, if the client detects that the target has recovered before reaching next_reconnect, calling `iscsi_reconnect/iscsi_force_reconnect` has no any effect, making fast reconnection impossible.

This patch introduces an interface to reset next_reconnect, so that the client can reset the backoff time upon detecting target recovery and achieve faster reconnection.

Resolves: https://github.com/sahlberg/libiscsi/issues/428