### PR TITLE
lib: reserve the fd on reconnect

### DIFF
--- a/lib/socket.c
+++ b/lib/socket.c
@@ -416,7 +416,11 @@ iscsi_tcp_disconnect(struct iscsi_context *iscsi)
 		return -1;
 	}
 
-	close(iscsi->fd);
+	if (iscsi->old_iscsi && iscsi->old_iscsi->fd == iscsi->fd) {
+		/* Reserve this fd because old_iscsi->fd will be reused */
+	} else {
+		close(iscsi->fd);
+	}
 
 	if (!(iscsi->pending_reconnect && iscsi->old_iscsi) &&
 	    iscsi->connected_portal[0]) {


### PR DESCRIPTION
On reconnect case, the iscsi_tcp_connect tries to reuse the fd number of old_iscsi. However, this fd could have been already closed in previous iscsi_tcp_disconnect if iscsi->fd == iscsi->old_iscsi->fd and the fd number might have been allocated to some other caller, in this case the fd reuse in iscsi_tcp_connect is not safe anymore.

Solve this by not closing the fd if iscsi and old_iscsi share the same fd on reconnect to "really" reserve this fd number.