### PR TITLE
lib: finish event_loop on invalid fd

### DIFF
--- a/lib/sync.c
+++ b/lib/sync.c
@@ -91,6 +91,12 @@ event_loop(struct iscsi_context *iscsi, struct iscsi_sync_state *state)
 			state->status = -1;
 			return;
 		}
+
+		if (iscsi->fd < 0) {
+			iscsi_set_error(iscsi, "Invalid fd %d", iscsi->fd);
+			state->status = -1;
+			return;
+		}
 	}
 }
 


### PR DESCRIPTION
When iscsi->fd gets invalid, there is not point to keep stuck in the event loop, instead could give an accurate error about the invalid fd.