### PR TITLE
Fix CHAP response buffer zero-init and increase MAX_CHAP_R_SIZE to support SHA-256

### DIFF
--- a/include/iscsi-private.h
+++ b/include/iscsi-private.h
@@ -98,7 +98,7 @@ struct iscsi_in_pdu {
 void iscsi_free_iscsi_in_pdu(struct iscsi_context *iscsi, struct iscsi_in_pdu *in);
 
 /* size of chap response field */
-#define MAX_CHAP_R_SIZE 20 /* md5:16  sha1:20 */
+#define MAX_CHAP_R_SIZE 32 /* md5:16  sha1:20 */
 
 /* max length of chap challange */
 #define MAX_CHAP_C_LENGTH 2048

--- a/lib/login.c
+++ b/lib/login.c
@@ -936,7 +936,7 @@ iscsi_login_add_chap_response(struct iscsi_context *iscsi, struct iscsi_pdu *pdu
 
 	/* bidirectional chap */
 	if (iscsi->target_user[0]) {
-		char target_chap_c[MAX_CHAP_R_SIZE * 2];
+		char target_chap_c[MAX_CHAP_R_SIZE * 2] = {0};
 
 		iscsi->target_chap_i++;
 		snprintf(str, MAX_STRING_SIZE, "CHAP_I=%d",


### PR DESCRIPTION
### Summary

This pull request addresses two related issues in the CHAP authentication code:

1. **Explicitly zero-initialize `target_chap_c` in `iscsi_login_add_chap_response()`**
   - Previously, the code relied on stack memory being zeroed, which is undefined behavior and could lead to unpredictable CHAP_C values.
   - This fix ensures that the buffer is safely initialized using `{0}`.

2. **Increase `MAX_CHAP_R_SIZE` to 32**
   - The previous value was insufficient to hold a full SHA-256 hash (32 bytes).
   - This change allows proper support for CHAP algorithms that require longer responses, such as SHA-256.

