### PR TITLE
Fix CHAP_C Encoding and CHAP_R Comparison in CHAP Authentication

### DIFF
--- a/include/iscsi-private.h
+++ b/include/iscsi-private.h
@@ -124,7 +124,7 @@ struct iscsi_context {
 	char target_user[MAX_STRING_SIZE+1];
 	char target_passwd[MAX_STRING_SIZE+1];
 	int target_chap_i;
-	char target_chap_r[MAX_CHAP_R_SIZE];
+	unsigned char target_chap_r[MAX_CHAP_R_SIZE];
 
 	char error_string[MAX_STRING_SIZE+1];
 

--- a/lib/login.c
+++ b/lib/login.c
@@ -937,7 +937,8 @@ iscsi_login_add_chap_response(struct iscsi_context *iscsi, struct iscsi_pdu *pdu
 	/* bidirectional chap */
 	if (iscsi->target_user[0]) {
 		char target_chap_c[MAX_CHAP_R_SIZE * 2] = {0};
-
+		char initiator_chap_c_hex[MAX_CHAP_R_SIZE * 4 + 1] = { 0 };
+		
 		iscsi->target_chap_i++;
 		snprintf(str, MAX_STRING_SIZE, "CHAP_I=%d",
 			 iscsi->target_chap_i);
@@ -962,6 +963,7 @@ iscsi_login_add_chap_response(struct iscsi_context *iscsi, struct iscsi_pdu *pdu
 			c = target_chap_c[i];
 			cc[0] = i2h((c >> 4)&0x0f);
 			cc[1] = i2h((c     )&0x0f);
+			memcpy(initiator_chap_c_hex + i * 2, cc, 2);
 			if (iscsi_pdu_add_data(iscsi, pdu, &cc[0], 2) != 0) {
 				iscsi_set_error(iscsi, "Out-of-memory: pdu add "
 						"data failed.");
@@ -977,7 +979,7 @@ iscsi_login_add_chap_response(struct iscsi_context *iscsi, struct iscsi_pdu *pdu
 
                 compute_chap_r(iscsi, iscsi->target_chap_i,
                                (unsigned char *)iscsi->target_passwd,
-                               (unsigned char *)target_chap_c,
+                               (unsigned char *)initiator_chap_c_hex,
                                (unsigned char *)iscsi->target_chap_r);
 	}
 

--- a/lib/login.c
+++ b/lib/login.c
@@ -937,7 +937,7 @@ iscsi_login_add_chap_response(struct iscsi_context *iscsi, struct iscsi_pdu *pdu
 	/* bidirectional chap */
 	if (iscsi->target_user[0]) {
 		char target_chap_c[MAX_CHAP_R_SIZE * 2] = {0};
-		char initiator_chap_c_hex[MAX_CHAP_R_SIZE * 4 + 1] = { 0 };
+		char target_chap_c_hex[MAX_CHAP_R_SIZE * 4 + 1] = { 0 };
 		
 		iscsi->target_chap_i++;
 		snprintf(str, MAX_STRING_SIZE, "CHAP_I=%d",
@@ -963,7 +963,7 @@ iscsi_login_add_chap_response(struct iscsi_context *iscsi, struct iscsi_pdu *pdu
 			c = target_chap_c[i];
 			cc[0] = i2h((c >> 4)&0x0f);
 			cc[1] = i2h((c     )&0x0f);
-			memcpy(initiator_chap_c_hex + i * 2, cc, 2);
+			memcpy(target_chap_c_hex + i * 2, cc, 2);
 			if (iscsi_pdu_add_data(iscsi, pdu, &cc[0], 2) != 0) {
 				iscsi_set_error(iscsi, "Out-of-memory: pdu add "
 						"data failed.");
@@ -979,7 +979,7 @@ iscsi_login_add_chap_response(struct iscsi_context *iscsi, struct iscsi_pdu *pdu
 
                 compute_chap_r(iscsi, iscsi->target_chap_i,
                                (unsigned char *)iscsi->target_passwd,
-                               (unsigned char *)initiator_chap_c_hex,
+                               (unsigned char *)target_chap_c_hex,
                                (unsigned char *)iscsi->target_chap_r);
 	}
 


### PR DESCRIPTION
#### 🐞 **Bug 1: Incorrect handling of CHAP\_C encoding during CHAP\_R computation**

In the function compute_chap_r_md5(), the chap_c parameter is expected to be a hex-encoded ASCII string (e.g., "0x1234abcd..."), which is parsed back into raw binary before being hashed into the CHAP\_R response.

However, the code that constructs CHAP_C was passing raw binary data (target_chap_c) directly into compute_chap_r_md5(), without converting it to the expected ASCII hex string format. This led to incorrect CHAP\_R generation and authentication failure.

✅ **Fix**: Before sending CHAP_C and computing CHAP_R, we now explicitly convert each byte of target_chap_c to a two-character hex string and store it in a new buffer (target_chap_c_hex), which is passed to compute_chap_r_md5().

---

#### 🐞 **Bug 2: Signed vs. unsigned byte mismatch in CHAP\_R comparison**

During the comparison of the received CHAP\_R response:

```c
if (c != iscsi->target_chap_r[i]) { ... }
```

c is unsigned char, while iscsi->target_chap_r[i] was originally declared as char. This may cause incorrect mismatches due to sign-extension when char is implicitly promoted to int during comparison (especially for byte values ≥ 128).

✅ **Fix**: The target_chap_r buffer has been updated to use unsigned char to avoid sign-extension issues during comparison with decoded CHAP_R bytes.

---
