### PR TITLE
fall-through in maintenancein unmarshal switch

### DIFF
--- a/lib/scsi-lowlevel.c
+++ b/lib/scsi-lowlevel.c
@@ -1359,6 +1359,8 @@ scsi_maintenancein_datain_unmarshall(struct scsi_task *task)
 			}
 			return rsoc_one;
 		}
+
+		break;
 	case SCSI_REPORT_TARGET_PORT_GROUPS:
 		return scsi_report_target_port_groups_unmarshal(task);
 	};


### PR DESCRIPTION
Fixing a potential fall-through in switch in data unmarshal function for maintenance-in commands. The fall-through never happens for valid commands, but the build tools may complain about it.