### PR TITLE
Fix linking of libiscsi to libpthread

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -230,6 +230,18 @@ AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
 	fi
 AM_CONDITIONAL([HAVE_PTHREAD], [test x$libiscsi_cv_HAVE_PTHREAD = xyes])
 
+# check for libpthread
+if test "$libiscsi_cv_HAVE_PTHREAD" = yes; then
+  ac_save_LIBS=$LIBS
+  AC_CHECK_LIB([pthread], [pthread_spin_lock], [])
+  LIBS="$ac_save_LIBS"
+  if test "$ac_cv_lib_pthread_pthread_spin_lock" = yes; then
+    LIBS_PRIVATE="-lpthread"
+  fi
+fi
+AC_SUBST(LIBS_PRIVATE)
+AM_CONDITIONAL([HAVE_PTHREAD_SPIN_LOCKS], [test x$ac_cv_lib_pthread_pthread_spin_lock = xyes])
+
 AC_CACHE_CHECK([whether libcunit is available],
                [ac_cv_have_cunit],
                [ac_save_CFLAGS="$CFLAGS"

--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -21,8 +21,14 @@ if HAVE_LINUX_ISER
 libiscsipriv_la_SOURCES += iser.c
 endif
 
+libiscsipriv_la_LIBADD =
+
+if HAVE_PTHREAD_SPIN_LOCKS
+libiscsipriv_la_LIBADD += -lpthread
+endif
+
 if HAVE_LINUX_ISER
-libiscsipriv_la_LIBADD = -libverbs -lrdmacm -lpthread
+libiscsipriv_la_LIBADD += -libverbs -lrdmacm
 endif
 
 libiscsipriv_la_LDFLAGS = -no-undefined

--- a/libiscsi.pc.in
+++ b/libiscsi.pc.in
@@ -8,5 +8,5 @@ Description: iSCSI initiator library
 Version: @VERSION@
 
 Libs: -L${libdir} -liscsi
-Libs.private:
+Libs.private: @LIBS_PRIVATE@
 Cflags: -I${includedir}


### PR DESCRIPTION
libiscsi utilizes a bunch of POSIX threads functions but does
not link against libpthread as it should nor the pkg-config file
properly listing libpthread as a static link time dependency.