### PR TITLE
configure: fix bogus TEST_CHAP_BASE64 conditional

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -109,7 +109,7 @@ if test "$WITH_LIBGCRYPT" != no; then
   WITH_LIBGCRYPT=$ac_cv_lib_gcrypt_gcry_control
 fi
 # gnutls_base64_encode2() was added >8 years ago so should be present
-AM_CONDITIONAL(TEST_CHAP_BASE64, [test "$WITH_LIBGCRYPT"])
+AM_CONDITIONAL(TEST_CHAP_BASE64, [test "$WITH_GNUTLS" = yes])
 
 NEED_MD5=no
 if test "$WITH_GNUTLS" = no && test "$WITH_LIBGCRYPT" = no; then


### PR DESCRIPTION
The conditional should be checking for gnutls presence.

On openSUSE Tumbleweed without gnutls this gives me:
  > ./test-tool/iscsi-test-cu --list|grep -i chap
  ALL.iSCSICHAP
  ALL.iSCSICHAP.Simple
  ALL.iSCSICHAP.Invalid
  iSCSI.iSCSICHAP
  iSCSI.iSCSICHAP.Simple
  iSCSI.iSCSICHAP.Invalid

Install gnutls, rebuild and check for base64 test presence:
  > sudo zypper in gnutls-devel

  > git clean -fxd .
  <rebuild>

  > ./test-tool/iscsi-test-cu --list|grep -i chap
  ALL.iSCSICHAP
  ALL.iSCSICHAP.Simple
  ALL.iSCSICHAP.Invalid
  ALL.iSCSICHAP.Base64
  ALL.iSCSICHAP.Base64Oversize
  iSCSI.iSCSICHAP
  iSCSI.iSCSICHAP.Simple
  iSCSI.iSCSICHAP.Invalid
  iSCSI.iSCSICHAP.Base64
  iSCSI.iSCSICHAP.Base64Oversize