### PR TITLE
ci: provision a loopback LIO iSCSI target and run test-tool/iscsi-test-cu against it

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,8 +2,6 @@ name: Build
 
 on:
   push:
-    branches:
-      - master
 
 jobs:
   build:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,3 +21,6 @@ jobs:
         sudo ci/lio_setup.sh
         # dump any LIO messages
         sudo dmesg --console-level info
+
+    - name: Run iscsi-test-cu against LIO iSCSI target
+      run: ci/run_test_tool.sh

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,3 +15,9 @@ jobs:
 
     - name: Build
       run: ci/build.sh
+
+    - name: Setup loopback LIO iSCSI target
+      run: |
+        sudo ci/lio_setup.sh
+        # dump any LIO messages
+        sudo dmesg --console-level info

--- a/ci/install.sh
+++ b/ci/install.sh
@@ -12,9 +12,7 @@ case "$(uname)" in
 	    libtool
 	    xsltproc
 	)
-	for p in "${packages[@]}"; do
-	    sudo sh -c "apt-get install -y $p"
-	done
+	apt-get install -y "${packages[@]}"
 	;;
     Darwin)
 	;;

--- a/ci/lio_setup.sh
+++ b/ci/lio_setup.sh
@@ -1,0 +1,121 @@
+#!/bin/bash -x
+
+_fatal() {
+	echo "Fatal Error $*"
+	exit 1
+}
+
+_warn() {
+	echo "WARNING $*"
+}
+
+TARGET_IQN="${TARGET_IQN:-iqn.2003-01.org.linux-iscsi:libiscsi:ci}"
+INITIATOR_IQNS="iqn.2007-10.com.github:sahlberg:libiscsi:iscsi-test iqn.2007-10.com.github:sahlberg:libiscsi:iscsi-test-2"
+# $ISCSI_USER and $ISCSI_PASS can also be set for CHAP configuration
+
+modprobe -a iscsi_target_mod target_core_file configfs || _fatal
+
+grep -m1 configfs /proc/mounts \
+	|| mount -t configfs configfs /sys/kernel/config/
+
+file_path=/lun_filer
+file_size_b="$((1024 * 1024 * 1024))"
+truncate --size="${file_size_b}" "$file_path" || _fatal
+
+mkdir -p /sys/kernel/config/target/iscsi || _fatal
+pushd /sys/kernel/config/target/core/ || _fatal
+mkdir -p fileio_0/filer || _fatal
+echo "fd_dev_name=${file_path}" > fileio_0/filer/control || _fatal
+echo "fd_dev_size=${file_size_b}" > fileio_0/filer/control || _fatal
+mkdir -p /var/target/alua/tpgs_myserial /var/target/pr || _fatal
+echo "myserial" > fileio_0/filer/wwn/vpd_unit_serial || _fatal
+echo "1" > fileio_0/filer/enable || _fatal
+# unmap/discard can't be set before "enable" for some reason...
+echo "1" > fileio_0/filer/attrib/emulate_tpu || _warn
+popd
+
+pushd /sys/kernel/config/target/iscsi || _fatal
+echo -n 0 > discovery_auth/enforce_discovery_auth
+mkdir -p "${TARGET_IQN}/tpgt_0/lun/lun_0" || _fatal
+ln -s /sys/kernel/config/target/core/fileio_0/filer \
+	"${TARGET_IQN}/tpgt_0/lun/lun_0/68c6222530" || _fatal
+
+echo 0 > "${TARGET_IQN}/tpgt_0/attrib/t10_pi"
+echo 0 > "${TARGET_IQN}/tpgt_0/attrib/default_erl"
+echo 1 > "${TARGET_IQN}/tpgt_0/attrib/demo_mode_discovery"
+echo 0 > "${TARGET_IQN}/tpgt_0/attrib/prod_mode_write_protect"
+echo 0 > "${TARGET_IQN}/tpgt_0/attrib/demo_mode_write_protect"
+echo 0 > "${TARGET_IQN}/tpgt_0/attrib/cache_dynamic_acls"
+echo 64 > "${TARGET_IQN}/tpgt_0/attrib/default_cmdsn_depth"
+echo 1 > "${TARGET_IQN}/tpgt_0/attrib/generate_node_acls"
+echo 2 > "${TARGET_IQN}/tpgt_0/attrib/netif_timeout"
+echo 15 > "${TARGET_IQN}/tpgt_0/attrib/login_timeout"
+
+if [[ -n "${ISCSI_USER}${ISCSI_PASS}" ]]; then
+	echo 1 > "${TARGET_IQN}/tpgt_0/attrib/authentication"
+	echo -n "$ISCSI_USER" > "${TARGET_IQN}/tpgt_0/auth/userid"
+	echo -n "$ISCSI_PASS" > "${TARGET_IQN}/tpgt_0/auth/password"
+else
+	# disable auth
+	echo 0 > "${TARGET_IQN}/tpgt_0/attrib/authentication"
+fi
+
+echo "2048~65535" > "${TARGET_IQN}/tpgt_0/param/OFMarkInt"
+echo "2048~65535" > "${TARGET_IQN}/tpgt_0/param/IFMarkInt"
+echo "No" > "${TARGET_IQN}/tpgt_0/param/OFMarker"
+echo "No" > "${TARGET_IQN}/tpgt_0/param/IFMarker"
+echo "0" > "${TARGET_IQN}/tpgt_0/param/ErrorRecoveryLevel"
+echo "Yes" > "${TARGET_IQN}/tpgt_0/param/DataSequenceInOrder"
+echo "Yes" > "${TARGET_IQN}/tpgt_0/param/DataPDUInOrder"
+echo "1" > "${TARGET_IQN}/tpgt_0/param/MaxOutstandingR2T"
+echo "20" > "${TARGET_IQN}/tpgt_0/param/DefaultTime2Retain"
+echo "2" > "${TARGET_IQN}/tpgt_0/param/DefaultTime2Wait"
+echo "65536" > "${TARGET_IQN}/tpgt_0/param/FirstBurstLength"
+echo "262144" > "${TARGET_IQN}/tpgt_0/param/MaxBurstLength"
+echo "262144" > "${TARGET_IQN}/tpgt_0/param/MaxXmitDataSegmentLength"
+echo "8192" > "${TARGET_IQN}/tpgt_0/param/MaxRecvDataSegmentLength"
+echo "Yes" > "${TARGET_IQN}/tpgt_0/param/ImmediateData"
+echo "Yes" > "${TARGET_IQN}/tpgt_0/param/InitialR2T"
+echo "LIO Target" > "${TARGET_IQN}/tpgt_0/param/TargetAlias"
+echo "1" > "${TARGET_IQN}/tpgt_0/param/MaxConnections"
+echo "CRC32C,None" > "${TARGET_IQN}/tpgt_0/param/DataDigest"
+echo "CRC32C,None" > "${TARGET_IQN}/tpgt_0/param/HeaderDigest"
+echo "CHAP,None" > "${TARGET_IQN}/tpgt_0/param/AuthMethod"
+popd
+
+for i in $INITIATOR_IQNS; do
+	mkdir -p "/sys/kernel/config/target/iscsi/${TARGET_IQN}/tpgt_0/acls/${i}" \
+		|| _fatal
+	pushd "/sys/kernel/config/target/iscsi/${TARGET_IQN}/tpgt_0/acls/${i}" \
+		|| _fatal
+
+	echo 64 > "cmdsn_depth"
+	# per-initiator ACL auth needs explicit config. It's not inherited
+	# from parent TPG.
+	if [[ -n "${ISCSI_USER}${ISCSI_PASS}" ]]; then
+		echo -n "$ISCSI_USER" > "auth/userid"
+		echo -n "$ISCSI_PASS" > "auth/password"
+	fi
+
+	echo 0 > "attrib/random_r2t_offsets"
+	echo 0 > "attrib/random_datain_seq_offsets"
+	echo 0 > "attrib/random_datain_pdu_offsets"
+	echo 30 > "attrib/nopin_response_timeout"
+	echo 15 > "attrib/nopin_timeout"
+	echo 0 > "attrib/default_erl"
+	echo 5 > "attrib/dataout_timeout_retries"
+	echo 3 > "attrib/dataout_timeout"
+
+	mkdir -p "lun_0" || _fatal
+	ln -s "/sys/kernel/config/target/iscsi/${TARGET_IQN}/tpgt_0/lun/lun_0" \
+		"lun_0/cafecafe"
+	echo 0 > "lun_0/write_protect"
+	popd || _fatal
+done
+
+mkdir "/sys/kernel/config/target/iscsi/${TARGET_IQN}/tpgt_0/np/127.0.0.1:3260" \
+	|| _fatal
+echo 1 > "/sys/kernel/config/target/iscsi/${TARGET_IQN}/tpgt_0/enable" \
+	|| _fatal
+
+echo "$(uname -r) LIO Target ready at: iscsi://127.0.0.1:3260/${TARGET_IQN}/0"

--- a/ci/run_test_tool.sh
+++ b/ci/run_test_tool.sh
@@ -1,0 +1,12 @@
+#!/bin/bash -x
+
+TARGET_IQN="${TARGET_IQN:-iqn.2003-01.org.linux-iscsi:libiscsi:ci}"
+chaps=""
+[[ -n "${ISCSI_USER}${ISCSI_PASS}" ]] && chaps="${ISCSI_USER}%${ISCSI_PASS}@"
+
+# Assume we are run from the compiled source.
+# Only run Read/Write10 tests for now. They're quick and pass against LIO.
+test-tool/iscsi-test-cu --dataloss --test "ALL.Read10" \
+	"iscsi://${chaps}127.0.0.1:3260/${TARGET_IQN}/0" || exit 1
+test-tool/iscsi-test-cu --dataloss --test "ALL.Write10" \
+	"iscsi://${chaps}127.0.0.1:3260/${TARGET_IQN}/0" || exit 1


### PR DESCRIPTION
The `ubuntu-latest` github runner already carries the LIO kernel modules, so setup a basic loopback iSCSI target via configfs and then run `test-tool/iscsi-test-cu` against it.
~~I currently have it running all tests, but it might make sense to only run a few sanity checks, or the example binaries. It'll likely burn through CI credits pretty quickly if used as-is.~~
_Edit: it's now only running Read10 and Write10 tests against the loopback target, which pass in around 3 minutes._

```
The following changes since commit 9ba97ca99e4670038212c2ba88cee68e4c0a7a7a:

  Merge pull request #470 from ddiss/chap_b64_fix_build_without_gnutls (2026-05-22 18:45:13 +1000)

are available in the Git repository at:

  https://github.com/ddiss/libiscsi.git lio-loopback-target

for you to fetch changes up to fc67ea0db26be6b52a252eb3bdf0384fcfa2caf4:

  ci: run iscsi-test-cu against the provisioned LIO target (2026-06-03 13:39:21 +1000)

----------------------------------------------------------------
David Disseldorp (4):
      ci: run on any branch push instead of only master
      ci/install: invoke apt-get install once
      ci: setup an LIO iSCSI target on loopback
      ci: run iscsi-test-cu against the provisioned LIO target

 .github/workflows/build.yml |  11 +++-
 ci/install.sh               |   4 +-
 ci/lio_setup.sh             | 121 ++++++++++++++++++++++++++++++++++++++++++++
 ci/run_test_tool.sh         |  12 +++++
 4 files changed, 143 insertions(+), 5 deletions(-)
 create mode 100755 ci/lio_setup.sh
 create mode 100755 ci/run_test_tool.sh
```