### PR TITLE
test-tool: CHAP name hex/base64 prefix tests

### DIFF
--- a/test-tool/iscsi-test-cu.c
+++ b/test-tool/iscsi-test-cu.c
@@ -587,6 +587,7 @@ static CU_TestInfo tests_iscsi_nop[] = {
 static CU_TestInfo tests_iscsi_chap[] = {
         { "Simple", test_iscsi_chap_simple },
         { "Invalid", test_iscsi_chap_invalid },
+        { "HexName", test_iscsi_chap_hex_name_prefix },
 #ifdef HAVE_LIBGNUTLS
         { "Base64", test_iscsi_chap_base64 },
         { "Base64Oversize", test_iscsi_chap_base64_oversize },

--- a/test-tool/iscsi-test-cu.c
+++ b/test-tool/iscsi-test-cu.c
@@ -591,6 +591,7 @@ static CU_TestInfo tests_iscsi_chap[] = {
 #ifdef HAVE_LIBGNUTLS
         { "Base64", test_iscsi_chap_base64 },
         { "Base64Oversize", test_iscsi_chap_base64_oversize },
+        { "Base64Name", test_iscsi_chap_base64_name_prefix },
 #endif
         CU_TEST_INFO_NULL
 };

--- a/test-tool/iscsi-test-cu.h
+++ b/test-tool/iscsi-test-cu.h
@@ -91,6 +91,7 @@ void test_iscsi_chap_hex_name_prefix(void);
 #ifdef HAVE_LIBGNUTLS
 void test_iscsi_chap_base64(void);
 void test_iscsi_chap_base64_oversize(void);
+void test_iscsi_chap_base64_name_prefix(void);
 #endif
 
 void test_mandatory_sbc(void);

--- a/test-tool/iscsi-test-cu.h
+++ b/test-tool/iscsi-test-cu.h
@@ -87,6 +87,7 @@ void test_iscsi_sendtargets_invalid(void);
 void test_iscsi_nop_simple(void);
 void test_iscsi_chap_simple(void);
 void test_iscsi_chap_invalid(void);
+void test_iscsi_chap_hex_name_prefix(void);
 #ifdef HAVE_LIBGNUTLS
 void test_iscsi_chap_base64(void);
 void test_iscsi_chap_base64_oversize(void);

--- a/test-tool/test_iscsi_chap.c
+++ b/test-tool/test_iscsi_chap.c
@@ -213,3 +213,30 @@ test_iscsi_chap_invalid(void)
 	ret = test_iscsi_chap_login(chap_mod_no_type_queue);
 	CU_ASSERT_EQUAL(ret, -EIO);
 }
+
+void
+test_iscsi_chap_hex_name_prefix(void)
+{
+        logging(LOG_VERBOSE, LOG_BLANK_LINE);
+        logging(LOG_VERBOSE, "Test CHAP_A negotiation");
+
+        CHECK_FOR_ISCSI(sd);
+        if (sd->iscsi_ctx->chap_a != 5) {
+                const char *err = "[SKIPPED] This test requires "
+                        "an iSCSI session with CHAP_A=5";
+                logging(LOG_NORMAL, "%s", err);
+                CU_PASS(err);
+                return;
+        }
+
+        if (strncmp(sd->iscsi_ctx->user, "0x", 2) &&
+            strncmp(sd->iscsi_ctx->user, "0X", 2)) {
+                const char *err = "[SKIPPED] This test requires "
+                        "an iSCSI CHAP username with hex prefix";
+                logging(LOG_NORMAL, "%s", err);
+                CU_PASS(err);
+                return;
+        }
+
+        // CHAP_N=0x... login succeeded if we get here
+}

--- a/test-tool/test_iscsi_chap_base64.c
+++ b/test-tool/test_iscsi_chap_base64.c
@@ -307,3 +307,30 @@ test_iscsi_chap_base64_oversize(void)
 	ret = test_iscsi_chap_login(chap_r_mod_b64_oversize_replace_queue);
 	CU_ASSERT_NOT_EQUAL(ret, 0);
 }
+
+void
+test_iscsi_chap_base64_name_prefix(void)
+{
+        logging(LOG_VERBOSE, LOG_BLANK_LINE);
+        logging(LOG_VERBOSE, "Test CHAP_A negotiation");
+
+        CHECK_FOR_ISCSI(sd);
+        if (sd->iscsi_ctx->chap_a != 5) {
+                const char *err = "[SKIPPED] This test requires "
+                        "an iSCSI session with CHAP_A=5";
+                logging(LOG_NORMAL, "%s", err);
+                CU_PASS(err);
+                return;
+        }
+
+        if (strncmp(sd->iscsi_ctx->user, "0b", 2) &&
+            strncmp(sd->iscsi_ctx->user, "0B", 2)) {
+                const char *err = "[SKIPPED] This test requires "
+                        "an iSCSI CHAP username with base64 prefix";
+                logging(LOG_NORMAL, "%s", err);
+                CU_PASS(err);
+                return;
+        }
+
+        // CHAP_N=0b... login succeeded if we get here
+}


### PR DESCRIPTION
These tests were helpful for reproducing an Linux LIO Target bug, where it removes `0x` and `0b` prefixes from `CHAP_N` parameters.

```
The following changes since commit 9ba97ca99e4670038212c2ba88cee68e4c0a7a7a:

  Merge pull request #470 from ddiss/chap_b64_fix_build_without_gnutls (2026-05-22 18:45:13 +1000)

are available in the Git repository at:

  https://github.com/ddiss/libiscsi.git chap_name_prefix

for you to fetch changes up to 602df4ce2468d75a0a290204f666e56213c769b4:

  test-tool: add CHAP Base64Name test (2026-06-02 16:59:37 +1000)

----------------------------------------------------------------
David Disseldorp (2):
      test-tool: add CHAP HexName test
      test-tool: add CHAP Base64Name test

 test-tool/iscsi-test-cu.c          |  2 ++
 test-tool/iscsi-test-cu.h          |  2 ++
 test-tool/test_iscsi_chap.c        | 27 +++++++++++++++++++++++++++
 test-tool/test_iscsi_chap_base64.c | 27 +++++++++++++++++++++++++++
 4 files changed, 58 insertions(+)
```