### PR TITLE
test-tool: add test to verify SVPD page codes are in ascending order

### DIFF
--- a/test-tool/Makefile.am
+++ b/test-tool/Makefile.am
@@ -36,6 +36,7 @@ iscsi_test_cu_SOURCES = iscsi-test-cu.c \
 	test_inquiry_mandatory_vpd_sbc.c \
 	test_inquiry_standard.c \
 	test_inquiry_supported_vpd.c \
+	test_inquiry_vpd_page_codes_sorted.c \
 	test_inquiry_version_descriptors.c \
 	test_iscsi_cmdsn_toohigh.c \
 	test_iscsi_cmdsn_toolow.c \

--- a/test-tool/iscsi-test-cu.c
+++ b/test-tool/iscsi-test-cu.c
@@ -89,6 +89,7 @@ static CU_TestInfo tests_inquiry[] = {
         { "BlockLimits", test_inquiry_block_limits},
         { "MandatoryVPDSBC", test_inquiry_mandatory_vpd_sbc},
         { "SupportedVPD", test_inquiry_supported_vpd},
+        { "VPDPageCodesSorted", test_inquiry_vpd_page_codes_sorted},
         { "VersionDescriptors", test_inquiry_version_descriptors},
         CU_TEST_INFO_NULL
 };

--- a/test-tool/iscsi-test-cu.h
+++ b/test-tool/iscsi-test-cu.h
@@ -76,6 +76,7 @@ void test_inquiry_evpd(void);
 void test_inquiry_mandatory_vpd_sbc(void);
 void test_inquiry_standard(void);
 void test_inquiry_supported_vpd(void);
+void test_inquiry_vpd_page_codes_sorted(void);
 void test_inquiry_version_descriptors(void);
 
 void test_iscsi_cmdsn_toohigh(void);

--- a/test-tool/test_inquiry_vpd_page_codes_sorted.c
+++ b/test-tool/test_inquiry_vpd_page_codes_sorted.c
@@ -1,0 +1,85 @@
+/* 
+   Copyright (C) 2026 by Badari Pulavarty <badarihp@github.com>
+   
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; either version 2 of the License, or
+   (at your option) any later version.
+   
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+   
+   You should have received a copy of the GNU General Public License
+   along with this program; if not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <stdio.h>
+
+#include <CUnit/CUnit.h>
+
+#include "iscsi.h"
+#include "scsi-lowlevel.h"
+#include "iscsi-support.h"
+#include "iscsi-test-cu.h"
+
+void
+test_inquiry_vpd_page_codes_sorted(void)
+{
+        int ret, i;
+        struct scsi_inquiry_supported_pages *sup_inq;
+
+        logging(LOG_VERBOSE, LOG_BLANK_LINE);
+        logging(LOG_VERBOSE, "Test INQUIRY Supported VPD page codes are in "
+                "ascending order");
+
+        logging(LOG_VERBOSE, "Send INQUIRY for Supported VPD Pages (0x00)");
+        ret = inquiry(sd, &task,
+                      1, SCSI_INQUIRY_PAGECODE_SUPPORTED_VPD_PAGES, 255,
+                      EXPECT_STATUS_GOOD);
+        CU_ASSERT_EQUAL(ret, 0);
+        if (ret != 0 || task == NULL) {
+                logging(LOG_NORMAL, "[FAILED] INQUIRY command failed");
+                goto out;
+        }
+
+        logging(LOG_VERBOSE, "Verify we got at least 4 bytes of data");
+        CU_ASSERT(task->datain.size >= 4);
+        if (task->datain.size < 4) {
+                logging(LOG_NORMAL, "[FAILED] DATA-IN too short");
+                goto out;
+        }
+
+        logging(LOG_VERBOSE, "Verify we can unmarshall the DATA-IN buffer");
+        sup_inq = scsi_datain_unmarshall(task);
+        CU_ASSERT_NOT_EQUAL(sup_inq, NULL);
+        if (sup_inq == NULL) {
+                logging(LOG_NORMAL, "[FAILED] Failed to unmarshall DATA-IN "
+                        "buffer");
+                goto out;
+        }
+
+        logging(LOG_VERBOSE, "Verify page codes are in ascending order "
+                "(SPC requirement)");
+        for (i = 1; i < sup_inq->num_pages; i++) {
+                if (sup_inq->pages[i] <= sup_inq->pages[i - 1]) {
+                        logging(LOG_NORMAL, "[FAILED] Page codes are not in "
+                                "ascending order. Page 0x%02x at index %d "
+                                "is not greater than page 0x%02x at index %d",
+                                sup_inq->pages[i], i,
+                                sup_inq->pages[i - 1], i - 1);
+                        CU_FAIL("VPD page codes are not in ascending order");
+                        goto out;
+                }
+        }
+
+        logging(LOG_VERBOSE, "All %d page codes are in ascending order",
+                sup_inq->num_pages);
+
+out:
+        if (task != NULL) {
+                scsi_free_scsi_task(task);
+                task = NULL;
+        }
+}


### PR DESCRIPTION
Per SPC specification, the Supported VPD Pages (page 0x00) INQUIRY response shall return page codes in ascending order. The existing test_inquiry_supported_vpd test verifies each listed page can be read but does not validate the ordering.

Add a new test (test_inquiry_vpd_page_codes_sorted) that sends an INQUIRY for Supported VPD Pages and asserts that each page code in the response is strictly greater than the previous one. The test properly handles error paths by routing all failures through a cleanup label.

Test output

Suite: Inquiry
  Test: VPDPageCodesSorted ...
    2026-06-10 16:41:59.350614     Test INQUIRY Supported VPD page codes are in ascending order
    2026-06-10 16:41:59.350655     Send INQUIRY for Supported VPD Pages (0x00)
    2026-06-10 16:41:59.350661     Send INQUIRY (Expecting SUCCESS) evpd:1 page_code:00 alloc_len:255
    2026-06-10 16:41:59.352403     [OK] INQUIRY returned SUCCESS NO SENSE(0x00) UNKNOWN(0x0000)
    2026-06-10 16:41:59.352502     Verify we got at least 4 bytes of data
    2026-06-10 16:41:59.352509     Verify we can unmarshall the DATA-IN buffer
    2026-06-10 16:41:59.352517     Verify page codes are in ascending order (SPC requirement)
    2026-06-10 16:41:59.352523     [FAILED] Page codes are not in ascending order. Page 0xb2 at index 5 is not greater than page 0xc0 at index 4
FAILED
    1. test_inquiry_vpd_page_codes_sorted.c:72  - CU_FAIL("VPD page codes are not in ascending order")    2026-06-10 16:41:59.352595     Send PRIN/READ_KEYS


Run Summary:    Type  Total    Ran Passed Failed Inactive
              suites      1      1    n/a      0        0
               tests      1      1      0      1        0
             asserts      4      4      3      1      n/a

Elapsed time =    0.001 seconds
Tests completed with return value: 0