### PR TITLE
Add GCD check, align bugfix for aarch64

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -247,6 +247,8 @@ AM_CONDITIONAL([HAVE_PTHREAD_SPIN_LOCKS], [test x$ac_cv_lib_pthread_pthread_spin
 # check for pthread_threadid_np
 AC_CHECK_FUNCS(pthread_threadid_np)
 
+AC_CHECK_HEADERS([dispatch/dispatch.h])
+
 AC_CACHE_CHECK([whether libcunit is available],
                [ac_cv_have_cunit],
                [ac_save_CFLAGS="$CFLAGS"

--- a/lib/scsi-lowlevel.c
+++ b/lib/scsi-lowlevel.c
@@ -1241,9 +1241,7 @@ scsi_report_target_port_groups_unmarshal(struct scsi_task *task)
 			if (rtpg == NULL) {
 				return NULL;
 			}
-			port = (uint16_t *)((uint8_t *)rtpg +
-					sizeof(struct scsi_report_target_port_groups) +
-					sizeof(struct scsi_target_port_group) * group_count);
+			port = (uint16_t *)&rtpg->groups[group_count];
 			rtpg->num_groups = group_count;
 			group_count = 0;
 			port_count = 0;


### PR DESCRIPTION
The library does not build without these patches using the default Xcode path since it can't find the grand central dispatch macro, and a pointer alignment warning is thrown by the compiler on ARM.

This commit should fix both! :D

```
randyzhu@Randys-MacBook-Pro libiscsi % gmake -C lib
gmake: Entering directory '/Users/randyzhu/Desktop/temp/libiscsi/lib'
/bin/sh ../libtool  --tag=CC   --mode=compile gcc -std=gnu23 -DHAVE_CONFIG_H -I. -I..  -I./../include -I./include  -Wall -W -Wshadow -Wstrict-prototypes -Wpointer-arith -Wcast-align -Wcast-qual -Wvla -Wno-unknown-warning-option -Wno-stringop-truncation -Wno-unused-parameter -Werror -Wwrite-strings -g -O2 -MT libiscsipriv_la-scsi-lowlevel.lo -MD -MP -MF .deps/libiscsipriv_la-scsi-lowlevel.Tpo -c -o libiscsipriv_la-scsi-lowlevel.lo `test -f 'scsi-lowlevel.c' || echo './'`scsi-lowlevel.c
libtool: compile:  gcc -std=gnu23 -DHAVE_CONFIG_H -I. -I.. -I./../include -I./include -Wall -W -Wshadow -Wstrict-prototypes -Wpointer-arith -Wcast-align -Wcast-qual -Wvla -Wno-unknown-warning-option -Wno-stringop-truncation -Wno-unused-parameter -Werror -Wwrite-strings -g -O2 -MT libiscsipriv_la-scsi-lowlevel.lo -MD -MP -MF .deps/libiscsipriv_la-scsi-lowlevel.Tpo -c scsi-lowlevel.c  -fno-common -DPIC -o .libs/libiscsipriv_la-scsi-lowlevel.o
scsi-lowlevel.c:1244:11: error: cast from 'uint8_t *' (aka 'unsigned char *') to 'uint16_t *' (aka 'unsigned short *') increases required alignment from 1 to 2 [-Werror,-Wcast-align]
 1244 |                         port = (uint16_t *)((uint8_t *)rtpg +
      |                                ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 1245 |                                         sizeof(struct scsi_report_target_port_groups) +
      |                                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 1246 |                                         sizeof(struct scsi_target_port_group) * group_count);
      |                                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
1 error generated.
gmake: *** [Makefile:629: libiscsipriv_la-scsi-lowlevel.lo] Error 1
gmake: Leaving directory '/Users/randyzhu/Desktop/temp/libiscsi/lib'
randyzhu@Randys-MacBook-Pro libiscsi % 
```

This *should* also fix #465.


